### PR TITLE
feat(store): migrate downloads to Vercel Blob Storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-downloads/*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 .vercel
+downloads/

--- a/downloads/build-in-public.zip
+++ b/downloads/build-in-public.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:210b48a95a14835c2fab46bd2c30f9fe614ab1b5a684c6d99e0cb7a5316e1522
-size 3078

--- a/downloads/cipher.zip
+++ b/downloads/cipher.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3045e2b206bd6008110ce9c1c26ff0446be1284cd8daf9914095404e115a03b3
-size 1237

--- a/downloads/coding-loops.zip
+++ b/downloads/coding-loops.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:499b8f2f4ee9b8fe5291f67f24feb7b0161ad48b4c8d1c1fae4964317477ba15
-size 2621

--- a/downloads/daily-briefing.zip
+++ b/downloads/daily-briefing.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff9c1ca5e8d05be8e41b84c9ac9e59e26cdf78e90e3e566b6ab16a055c5f7871
-size 2771

--- a/downloads/echo.zip
+++ b/downloads/echo.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fb8525f7d6fac7add8402053288fb1d724140b20c60d6293081a40840871d72
-size 1438

--- a/downloads/forge.zip
+++ b/downloads/forge.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1a1cdde6c534fb20e8f62ce76d0e9b42d917cc24a9f7de5dd3b86fd4f32f852
-size 1407

--- a/downloads/humanizer.zip
+++ b/downloads/humanizer.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90f05026439dad59164409c87485b58569cd55d8b26079c6e1bf4197e54d1845
-size 10131

--- a/downloads/lyra.zip
+++ b/downloads/lyra.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d24898a6519fef624366ec3141b552561bda5fe51b668aeb6f38e831067d5068
-size 1291

--- a/downloads/onchain-treasury.zip
+++ b/downloads/onchain-treasury.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8d75d22c744022fb589990313f33af83f54263e9bdca3fed03d37a84b85812c
-size 2674

--- a/downloads/pixel.zip
+++ b/downloads/pixel.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:852a43532a4a9a931f100422b419a96f7d671fa3efba0a36267c146149dd3f86
-size 1376

--- a/downloads/prism.zip
+++ b/downloads/prism.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ab1381b6aa1cfb7b575980ee74335685e8c51d0894995feb2a7f152937f51e1
-size 1316

--- a/downloads/quill.zip
+++ b/downloads/quill.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:270bd5b7b415223bcddf933c9c2c05103682b9229f8fc9c44b27a808e69efd4e
-size 1289

--- a/downloads/rally.zip
+++ b/downloads/rally.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2dfac68754a9837394f4dae609832795b0e152d407e092783420e0cb4040645
-size 1264

--- a/downloads/sage.zip
+++ b/downloads/sage.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61aa05280124f60ac50dd216566d2c9ac5bd1e1b695fff649c472db16d17c3c9
-size 1219

--- a/downloads/stripe-revenue-tracker.zip
+++ b/downloads/stripe-revenue-tracker.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c77c87720f7bc73c3aa8cca3f13395d2291d3ad6956becf16bf3d1ff9d52e034
-size 2443

--- a/downloads/tmux-coding-sessions.zip
+++ b/downloads/tmux-coding-sessions.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:804e0101d9ed061d26bd6de86d2b40fbc3a005ff04169183015538343b500eea
-size 2052

--- a/scripts/upload-to-blob.mjs
+++ b/scripts/upload-to-blob.mjs
@@ -1,0 +1,50 @@
+/**
+ * Upload all downloads/*.zip to Vercel Blob Storage.
+ *
+ * Usage:
+ *   BLOB_READ_WRITE_TOKEN=vercel_blob_... node scripts/upload-to-blob.mjs
+ *
+ * Each file is uploaded with addRandomSuffix: false so the URL is deterministic:
+ *   https://<store>.public.blob.vercel-storage.com/downloads/<slug>.zip
+ */
+
+import { put, list } from '@vercel/blob';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+const DOWNLOADS_DIR = join(process.cwd(), 'downloads');
+
+async function main() {
+    const files = readdirSync(DOWNLOADS_DIR).filter(f => f.endsWith('.zip'));
+    console.log(`Found ${files.length} zip files to upload\n`);
+
+    for (const file of files) {
+        const filePath = join(DOWNLOADS_DIR, file);
+        const blobPath = `downloads/${file}`;
+        const data = readFileSync(filePath);
+
+        console.log(`Uploading ${file} (${(data.length / 1024).toFixed(0)} KB)...`);
+
+        const blob = await put(blobPath, data, {
+            access: 'public',  // URL is public but unguessable; download API still gates access
+            addRandomSuffix: false,
+            contentType: 'application/zip',
+        });
+
+        console.log(`  → ${blob.url}\n`);
+    }
+
+    console.log('Done! All files uploaded to Vercel Blob.');
+
+    // List all blobs to confirm
+    console.log('\n--- Blob listing ---');
+    const { blobs } = await list({ prefix: 'downloads/' });
+    for (const b of blobs) {
+        console.log(`  ${b.pathname} (${(b.size / 1024).toFixed(0)} KB)`);
+    }
+}
+
+main().catch(err => {
+    console.error('Upload failed:', err);
+    process.exit(1);
+});

--- a/scripts/upload-to-blob.mjs
+++ b/scripts/upload-to-blob.mjs
@@ -26,7 +26,7 @@ async function main() {
         console.log(`Uploading ${file} (${(data.length / 1024).toFixed(0)} KB)...`);
 
         const blob = await put(blobPath, data, {
-            access: 'public',  // URL is public but unguessable; download API still gates access
+            access: 'private',
             addRandomSuffix: false,
             contentType: 'application/zip',
         });

--- a/src/pages/api/download.ts
+++ b/src/pages/api/download.ts
@@ -9,11 +9,13 @@ const VALID_SLUGS = [
   "cipher", "sage", "quill", "rally", "echo", "pixel", "forge", "prism", "lyra",
 ];
 
-/** Map slug → Vercel Blob URL (set via env, populated by upload script) */
-function getBlobUrl(slug: string): string {
+/** Construct Blob URL and auth for private store */
+function getBlobConfig(slug: string): { url: string; token: string } {
   const baseUrl = import.meta.env.BLOB_STORE_BASE_URL;
+  const token = import.meta.env.BLOB_READ_WRITE_TOKEN;
   if (!baseUrl) throw new Error("BLOB_STORE_BASE_URL not configured");
-  return `${baseUrl}/downloads/${slug}.zip`;
+  if (!token) throw new Error("BLOB_READ_WRITE_TOKEN not configured");
+  return { url: `${baseUrl}/downloads/${slug}.zip`, token };
 }
 
 async function verifySessionAndDevice(
@@ -71,8 +73,10 @@ export const GET: APIRoute = async ({ request }) => {
 
   // Fetch from Vercel Blob (private storage)
   try {
-    const blobUrl = getBlobUrl(slug);
-    const blobRes = await fetch(blobUrl);
+    const { url: blobUrl, token } = getBlobConfig(slug);
+    const blobRes = await fetch(blobUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
 
     if (!blobRes.ok) {
       console.error(`Blob fetch failed for ${slug}: ${blobRes.status}`);

--- a/src/pages/api/download.ts
+++ b/src/pages/api/download.ts
@@ -1,8 +1,6 @@
 export const prerender = false;
 
 import type { APIRoute } from "astro";
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
 
 const VALID_SLUGS = [
   "aleister-persona",
@@ -10,6 +8,13 @@ const VALID_SLUGS = [
   "onchain-treasury", "build-in-public", "daily-briefing", "stripe-revenue-tracker",
   "cipher", "sage", "quill", "rally", "echo", "pixel", "forge", "prism", "lyra",
 ];
+
+/** Map slug → Vercel Blob URL (set via env, populated by upload script) */
+function getBlobUrl(slug: string): string {
+  const baseUrl = import.meta.env.BLOB_STORE_BASE_URL;
+  if (!baseUrl) throw new Error("BLOB_STORE_BASE_URL not configured");
+  return `${baseUrl}/downloads/${slug}.zip`;
+}
 
 async function verifySessionAndDevice(
   sessionId: string,
@@ -64,20 +69,29 @@ export const GET: APIRoute = async ({ request }) => {
     return new Response(reason ?? "Not authorized", { status: 403 });
   }
 
-  const zipPath = join(process.cwd(), "downloads", `${slug}.zip`);
-  if (!existsSync(zipPath)) {
-    return new Response("Bundle not found", { status: 404 });
+  // Fetch from Vercel Blob (private storage)
+  try {
+    const blobUrl = getBlobUrl(slug);
+    const blobRes = await fetch(blobUrl);
+
+    if (!blobRes.ok) {
+      console.error(`Blob fetch failed for ${slug}: ${blobRes.status}`);
+      return new Response("Bundle not found", { status: 404 });
+    }
+
+    const fileBuffer = await blobRes.arrayBuffer();
+
+    return new Response(fileBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${slug}.zip"`,
+        "Content-Length": String(fileBuffer.byteLength),
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    console.error(`Download error for ${slug}:`, err);
+    return new Response("Download service unavailable", { status: 503 });
   }
-
-  const fileBuffer = readFileSync(zipPath);
-
-  return new Response(fileBuffer, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/zip",
-      "Content-Disposition": `attachment; filename="${slug}.zip"`,
-      "Content-Length": String(fileBuffer.length),
-      "Cache-Control": "no-store",
-    },
-  });
 };


### PR DESCRIPTION
## Summary
Migrate all 17 store download zip files from Git LFS to **Vercel Blob Storage** (private).

## Changes
- **`src/pages/api/download.ts`** — fetch from Vercel Blob (private, with auth header) instead of local filesystem
- **`scripts/upload-to-blob.mjs`** — upload script for deploying zips to Blob store
- **`.gitignore`** — added `downloads/` to prevent product files from entering the repo
- **`.gitattributes`** — removed LFS tracking (no longer needed)
- **Deleted** all 16 placeholder zips from git tracking

## Security
- Blob store is **private** — URLs require `BLOB_READ_WRITE_TOKEN` to access
- `/api/download` is the only access path — requires Stripe session + device token verification
- No product files in the repository whatsoever

## Env Vars Required on Vercel
- `BLOB_READ_WRITE_TOKEN` ✅ (already set)
- `BLOB_STORE_BASE_URL` = `https://n8ypfmz2pjuodawc.private.blob.vercel-storage.com` ⚠️ **needs to be added**

Resolves #75