### PR TITLE
ui: move theme toggle to footer + fix FundlyHub card flashing $0

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeToggle from "./ThemeToggle.astro";
+
 const subagents = [
   { name: 'Cipher', codename: 'Coder' },
   { name: 'Sage', codename: 'Researcher' },
@@ -99,6 +101,9 @@ const subagents = [
             </svg>
           </a>
         </div>
+        <div class="footer__theme">
+          <ThemeToggle />
+        </div>
       </div>
 
       <div class="footer__col">
@@ -198,6 +203,10 @@ const subagents = [
   .footer__socials {
     display: flex;
     gap: 0.75rem;
+    margin-top: 0.75rem;
+  }
+
+  .footer__theme {
     margin-top: 0.75rem;
   }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,4 @@
 ---
-import ThemeToggle from "./ThemeToggle.astro";
-
 const currentPath = Astro.url.pathname;
 function isActive(href: string): boolean {
   if (href.startsWith("/#")) return currentPath === "/";
@@ -120,7 +118,6 @@ const standaloneLinks = [{ label: "Dashboard", href: "/dashboard" }];
     </ul>
 
     <div class="header__actions">
-      <ThemeToggle />
       <a
         href="https://x.com/TheAleister_"
         target="_blank"

--- a/src/pages/api/fundlyhub-revenue.json.ts
+++ b/src/pages/api/fundlyhub-revenue.json.ts
@@ -39,13 +39,11 @@ export const GET: APIRoute = async () => {
             return allCharges;
         }
 
-        // Fetch all charges with full pagination
-        const [allCharges, charges30dCharges] = await Promise.all([
-            fetchAllCharges('', 15000),
-            fetchAllCharges(`created[gte]=${thirtyDaysAgo}`, 8000),
-        ]);
+        // Fetch all charges with full pagination — derive 30d from the same set
+        // (avoids a redundant second pagination round-trip to Stripe, which was
+        // the primary cold-start timeout source)
+        const allCharges = await fetchAllCharges('', 20000);
 
-        // All-time successful charges (already fetched with full pagination)
         const allSuccessful = allCharges.filter(
             (c: any) => c.status === 'succeeded' && !c.refunded
         );
@@ -54,9 +52,8 @@ export const GET: APIRoute = async () => {
             0
         ) / 100;
 
-        // 30d successful charges (already fetched with full pagination)
-        const successful30d = charges30dCharges.filter(
-            (c: any) => c.status === 'succeeded' && !c.refunded
+        const successful30d = allSuccessful.filter(
+            (c: any) => (c.created || 0) >= thirtyDaysAgo
         );
         const revenue30d = successful30d.reduce(
             (sum: number, c: any) => sum + (c.amount || 0),
@@ -102,7 +99,10 @@ export const GET: APIRoute = async () => {
                 status: 200,
                 headers: {
                     'Content-Type': 'application/json',
-                    'Cache-Control': 'public, max-age=300',
+                    // Serve the cached response while a background revalidation
+                    // happens — eliminates the "$0 on cold start" UX where the
+                    // first request was slow enough to time out.
+                    'Cache-Control': 'public, max-age=300, stale-while-revalidate=86400',
                 },
             }
         );

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -1236,10 +1236,20 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     // ──── FundlyHub Revenue → FundlyHub card ────
-    async function fetchFundlyHubRevenue() {
+    async function fetchFundlyHubRevenue(attempt = 0) {
       try {
         const res = await fetch("/api/fundlyhub-revenue.json");
         const data = await res.json();
+
+        // API ran out of time paginating Stripe and returned the zero-fallback.
+        // Don't clobber the UI with $0 — retry shortly, and let the next poll
+        // pick up the cached (stale-while-revalidate) value.
+        if (data.success === false) {
+          if (attempt < 3) {
+            setTimeout(() => fetchFundlyHubRevenue(attempt + 1), 2000 * (attempt + 1));
+          }
+          return;
+        }
 
         const amountEl = document.getElementById("fundlyhub-revenue");
         const subEl = document.getElementById("fundlyhub-sub");
@@ -1255,6 +1265,9 @@ const CLAW_MART_EARNINGS = 94;
         updateAllTimeRevenue();
       } catch (err) {
         console.error("FundlyHub revenue fetch error:", err);
+        if (attempt < 3) {
+          setTimeout(() => fetchFundlyHubRevenue(attempt + 1), 2000 * (attempt + 1));
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Two unrelated improvements bundled on one branch.

### 1. Move theme toggle from nav bar to footer
- Removed `<ThemeToggle />` from `Header.astro`'s `.header__actions`.
- Added it to `Footer.astro` in the brand column, beneath the social icons (`.footer__theme` wrapper, 0.75rem top margin to match `.footer__socials`).
- Office pages (`/office/*`) have their own standalone toggle outside the nav bar — left untouched, those are separate from the nav.

### 2. Stop FundlyHub card flashing $0 on cold start
Root cause: `/api/fundlyhub-revenue.json` was making **two** parallel paginated Stripe fetches (all-time + 30d). On cold start the function could exceed its timeout, fall into the `catch` block, and return `{success: false, totalRevenue: 0}`. The client wrote that 0 to the DOM, so the card showed `$0.00` until the next 60s auto-refresh.

**Server** (`src/pages/api/fundlyhub-revenue.json.ts`):
- Drop the redundant 30d pagination — filter the 30d window from the all-time result set we already have. Halves Stripe round-trips and the chance of timeout.
- Cache header is now `public, max-age=300, stale-while-revalidate=86400` so cached responses serve immediately on cold start while revalidation happens in the background.

**Client** (`src/pages/dashboard.astro`):
- `fetchFundlyHubRevenue` now bails out before touching the DOM when `data.success === false`, so the `—` placeholder stays in place instead of flashing `$0.00`.
- Retries up to 3 times with 2/4/6 s linear backoff on failure (network error or `success: false`).

## Test plan

- [ ] Verify nav bar no longer renders the sun/half/moon toggle on any page.
- [ ] Verify the toggle now appears in the footer's brand column, below the social icons, and cycling through light → system → dark still works.
- [ ] Hard-refresh `/dashboard` a few times against a cold Vercel function — FundlyHub card should never display `$0.00`; it should stay on `—` until the real value arrives.
- [ ] Confirm the displayed FundlyHub total matches what Stripe shows for all successful, non-refunded charges.

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_