### PR TITLE
seo(robots): expand AI-bot allowlist

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,16 +4,17 @@
 User-agent: *
 Allow: /
 
-# Allow AI bots (Phase 1 SEO requirement)
+# ── OpenAI ──
 User-agent: GPTBot
 Allow: /
 
 User-agent: ChatGPT-User
 Allow: /
 
-User-agent: Google-Extended
+User-agent: OAI-SearchBot
 Allow: /
 
+# ── Google ──
 User-agent: Googlebot
 Allow: /
 
@@ -26,22 +27,102 @@ Allow: /
 User-agent: Googlebot-Video
 Allow: /
 
-User-agent: PerplexityBot
+User-agent: Google-Extended
 Allow: /
 
+User-agent: GoogleOther
+Allow: /
+
+# ── Anthropic ──
 User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
 Allow: /
 
 User-agent: anthropic-ai
 Allow: /
 
+# ── Perplexity ──
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# ── Apple ──
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# ── Meta ──
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Meta-ExternalFetcher
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+# ── Microsoft / Bing ──
+User-agent: Bingbot
+Allow: /
+
+User-agent: BingPreview
+Allow: /
+
+# ── Amazon ──
+User-agent: Amazonbot
+Allow: /
+
+# ── ByteDance ──
 User-agent: Bytespider
 Allow: /
 
+# ── Common Crawl (training data for many models) ──
+User-agent: CCBot
+Allow: /
+
+# ── DuckDuckGo ──
+User-agent: DuckDuckBot
+Allow: /
+
+# ── Yandex ──
+User-agent: YandexBot
+Allow: /
+
+# ── Brave Search ──
+User-agent: Bravebot
+Allow: /
+
+# ── Mistral ──
+User-agent: MistralAI-User
+Allow: /
+
+# ── Cohere ──
+User-agent: cohere-ai
+Allow: /
+
+User-agent: cohere-training-data-crawler
+Allow: /
+
+# ── Social previews ──
 User-agent: Discordbot
 Allow: /
 
 User-agent: Twitterbot
+Allow: /
+
+User-agent: LinkedInBot
+Allow: /
+
+User-agent: Slackbot
+Allow: /
+
+User-agent: TelegramBot
 Allow: /
 
 # Sitemap location


### PR DESCRIPTION
## Summary

The `public/robots.txt` says it's "Optimized for AI bot crawling" but was missing several high-traffic crawlers that emerged since it was last touched. Expanded and grouped the allowlist by vendor:

- **OpenAI**: + OAI-SearchBot
- **Google**: + GoogleOther
- **Anthropic**: + Claude-Web
- **Perplexity**: + Perplexity-User
- **Apple**: + Applebot, Applebot-Extended
- **Meta**: + Meta-ExternalAgent, Meta-ExternalFetcher, FacebookBot
- **Microsoft / Bing**: + Bingbot, BingPreview
- **Amazon**: + Amazonbot
- **Common Crawl**: + CCBot (training-data crawler used by many open models)
- **DuckDuckGo, Yandex, Brave, Mistral, Cohere**
- **Social previews**: + LinkedInBot, Slackbot, TelegramBot

## Sitemap — no change needed

`src/pages/sitemap.xml.ts` already iterates `blogPosts` from the data file, so the 5 new May 2026 posts are picked up automatically. The endpoint is cached `max-age=3600`, so the new URLs surface to crawlers within an hour. No code change required.

## Test plan
- [ ] `curl https://thealeister.com/robots.txt` returns the expanded file.
- [ ] `curl https://thealeister.com/sitemap.xml` includes the 5 new `/blog/<slug>/` URLs.
- [ ] Submit `/sitemap.xml` to Google Search Console and Bing Webmaster Tools to nudge re-indexing.

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_