### PR TITLE
feat(home): live activity strip in hero + dashboard CTA (preview)

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,4 +1,27 @@
 ---
+import { blogPosts } from "../data/blog-posts";
+
+const sorted = [...blogPosts].sort(
+  (a, b) => +new Date(b.publishDate) - +new Date(a.publishDate),
+);
+const latestPost = sorted[0];
+const latestDays = latestPost
+  ? Math.max(
+      0,
+      Math.round(
+        (Date.now() - new Date(latestPost.publishDate).getTime()) /
+          (1000 * 60 * 60 * 24),
+      ),
+    )
+  : null;
+const latestAgo =
+  latestDays === null
+    ? ""
+    : latestDays === 0
+      ? "today"
+      : latestDays === 1
+        ? "yesterday"
+        : `${latestDays}d ago`;
 ---
 
 <section class="hero" id="hero">
@@ -67,10 +90,37 @@
       </div>
     </div>
 
+    <div class="hero__live" id="hero-live">
+      <span class="hero__live-seg hero__live-seg--status">
+        <span class="hero__live-dot"></span>
+        <span class="hero__live-text" id="hero-live-agents">Aleister + 9 sub-agents</span>
+      </span>
+      <span class="hero__live-divider"></span>
+      <span class="hero__live-seg">
+        <span class="hero__live-label">$ALEISTER</span>
+        <span class="hero__live-text mono" id="hero-live-token">—</span>
+      </span>
+      <span class="hero__live-divider"></span>
+      <span class="hero__live-seg">
+        <span class="hero__live-text mono" id="hero-live-rev">—</span>
+        <span class="hero__live-label">all-time</span>
+      </span>
+      {
+        latestPost && (
+          <>
+            <span class="hero__live-divider"></span>
+            <a class="hero__live-seg hero__live-seg--link" href={`/blog/${latestPost.slug}`}>
+              <span class="hero__live-label">Latest</span>
+              <span class="hero__live-text">{latestAgo} →</span>
+            </a>
+          </>
+        )
+      }
+    </div>
+
     <div class="hero__cta">
       <a href="/get" class="btn btn-primary">Get Aleister →</a>
-      <a href="#about" class="btn btn-secondary">Discover More ↓</a>
-
+      <a href="/dashboard" class="btn btn-secondary">Live Dashboard →</a>
     </div>
   </div>
 
@@ -89,6 +139,110 @@
       gif.src = gifSrc;
     });
   }
+</script>
+
+<script is:inline>
+  (function () {
+    function fmtCurrency(n) {
+      if (!isFinite(n) || n <= 0) return "—";
+      if (n >= 1e6) return "$" + (n / 1e6).toFixed(2) + "M";
+      if (n >= 1e3) return "$" + (n / 1e3).toFixed(1) + "K";
+      return "$" + n.toFixed(2);
+    }
+    function fmtTokenPrice(p) {
+      if (!isFinite(p) || p <= 0) return "—";
+      if (p < 0.01) return "$" + p.toFixed(6);
+      if (p < 1) return "$" + p.toFixed(4);
+      return "$" + p.toFixed(2);
+    }
+
+    async function loadAgentStatus() {
+      try {
+        const r = await fetch("/api/agent-status.json");
+        const d = await r.json();
+        if (!d || d.success === false) return;
+        const total = d.summary?.total ?? 10;
+        const working = d.summary?.working ?? 0;
+        const el = document.getElementById("hero-live-agents");
+        if (el) {
+          el.textContent =
+            working > 0
+              ? "Aleister + " + (total - 1) + " sub-agents · " + working + " working"
+              : "Aleister + " + (total - 1) + " sub-agents online";
+        }
+      } catch (_) {}
+    }
+
+    async function loadTokenPrice() {
+      try {
+        const r = await fetch("/api/token-prices.json");
+        const d = await r.json();
+        const p = d?.aleister?.usd;
+        const ch = d?.aleister?.usd_24h_change;
+        if (typeof p !== "number" || p <= 0) return;
+        const el = document.getElementById("hero-live-token");
+        if (!el) return;
+        const chStr =
+          typeof ch === "number"
+            ? " (" + (ch >= 0 ? "+" : "") + ch.toFixed(1) + "%)"
+            : "";
+        el.textContent = fmtTokenPrice(p) + chStr;
+        el.classList.remove("up", "down");
+        if (typeof ch === "number") {
+          el.classList.add(ch >= 0 ? "up" : "down");
+        }
+      } catch (_) {}
+    }
+
+    async function loadRevenue() {
+      try {
+        const [storeRes, fhRes] = await Promise.all([
+          fetch("/api/store-revenue.json"),
+          fetch("/api/fundlyhub-revenue.json"),
+        ]);
+        const [store, fh] = await Promise.all([
+          storeRes.json(),
+          fhRes.json(),
+        ]);
+        let total = 0;
+        if (store && store.success !== false && store.productRevenue) {
+          total += Object.values(store.productRevenue).reduce(
+            (s, v) => s + (Number(v) || 0),
+            0,
+          );
+        }
+        if (fh && fh.success !== false && typeof fh.totalRevenue === "number") {
+          total += fh.totalRevenue;
+        }
+        // Claw Mart baseline (matches dashboard fallback) so the figure
+        // reflects what visitors see on /dashboard.
+        total += 94;
+        if (total <= 0) return;
+        const el = document.getElementById("hero-live-rev");
+        if (el) el.textContent = fmtCurrency(total);
+      } catch (_) {}
+    }
+
+    function refreshAll() {
+      loadAgentStatus();
+      loadTokenPrice();
+      loadRevenue();
+    }
+
+    let interval;
+    document.addEventListener("astro:page-load", function () {
+      if (!document.getElementById("hero-live")) return;
+      refreshAll();
+      if (interval) clearInterval(interval);
+      interval = setInterval(refreshAll, 60000);
+    });
+    document.addEventListener("astro:before-swap", function () {
+      if (interval) {
+        clearInterval(interval);
+        interval = undefined;
+      }
+    });
+  })();
 </script>
 
 <style>
@@ -286,6 +440,94 @@
     display: flex;
     gap: 1rem;
     margin-top: 0.5rem;
+  }
+
+  /* ─── Live activity strip ─── */
+  .hero__live {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.1rem;
+    flex-wrap: wrap;
+    padding: 0.55rem 1.1rem;
+    margin-top: -0.25rem;
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    max-width: 100%;
+  }
+
+  .hero__live-seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    white-space: nowrap;
+  }
+
+  .hero__live-seg--link {
+    text-decoration: none;
+    color: inherit;
+    transition: color 0.15s ease;
+  }
+
+  .hero__live-seg--link:hover {
+    color: var(--text-accent);
+  }
+
+  .hero__live-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #10b981;
+    box-shadow: 0 0 6px rgba(16, 185, 129, 0.6);
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+
+  .hero__live-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    font-weight: 600;
+  }
+
+  .hero__live-text {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .hero__live-text.up {
+    color: #10b981;
+  }
+
+  .hero__live-text.down {
+    color: #ef4444;
+  }
+
+  .hero__live-divider {
+    width: 1px;
+    height: 14px;
+    background: var(--border-subtle);
+  }
+
+  @keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.55; transform: scale(0.85); }
+  }
+
+  @media (max-width: 640px) {
+    .hero__live {
+      gap: 0.6rem 0.9rem;
+      padding: 0.6rem 0.9rem;
+      font-size: 0.72rem;
+    }
+    .hero__live-divider {
+      display: none;
+    }
   }
 
   /* Scroll indicator */


### PR DESCRIPTION
## Preview branch — do not merge yet

This PR exists so Vercel auto-deploys a preview URL for design review. Once you're happy, mark "Ready for review" and merge; or close and I'll iterate.

## What changed

**Live activity strip** added to the hero, sitting between the existing 4-stat row and the CTAs. Thin glass pill, 4 segments separated by dividers, all driven by real endpoints (no fabricated numbers):

| Segment | Source | Behavior |
|---|---|---|
| 🟢 `Aleister + 9 sub-agents · X working` | `/api/agent-status.json` | Reflects the same status the office page uses; gateway-aware |
| `$ALEISTER $X.XX (±Y.Y%)` | `/api/token-prices.json` | Green when up, red when down |
| `$X.XK all-time` | sum of `/api/store-revenue.json` + `/api/fundlyhub-revenue.json` + ClawMart baseline | Matches the Dashboard's all-time figure |
| `Latest <relative-date> →` | newest entry in `src/data/blog-posts.ts` (build-time) | Links to that post |

**Cold-start handling:** each fetch fails silently and leaves the `—` placeholder instead of writing $0 — same pattern as the recent FundlyHub dashboard fix.

**Auto-refresh:** every 60s. Interval is cleared on `astro:before-swap` so view-transitions don't accumulate timers.

**Secondary CTA swap:** `"Discover More ↓"` (a weak same-page anchor) → `"Live Dashboard →"` pointing at `/dashboard`. The strip naturally funnels into the dashboard, so this turns the strongest social-proof page into a one-click destination from the hero.

## What it looks like (textual)

```
                    [animated avatar]
                       [Online]
                I'm  Aleister
        AI agent of Vitaliy Rusavuk — orchestrating 9
        specialized subagents across multiple LLMs.
        Living in a Mac Mini M4 in El Dorado Hills, CA.

       ┌─────┬─────┬─────┬─────┐
       │  9  │  9  │  6  │  4  │   ← existing static identity row
       └─────┴─────┴─────┴─────┘

   ( ● Aleister + 9 sub-agents · 3 working │ $ALEISTER $X.XX +9.3% │ $23.9K all-time │ Latest 2d ago → )
                                                                                                  ↑ NEW

       [ Get Aleister → ]   [ Live Dashboard → ]
                                  ↑ was "Discover More ↓"
```

## Test plan
- [ ] Load `/` cold — strip shows `—` placeholders, then fills in within ~1s
- [ ] Refresh repeatedly — no `$0` flashing on any segment
- [ ] Token-price color flips correctly on negative 24h change
- [ ] Mobile (≤640px) — segments wrap to two lines, dividers hide
- [ ] Click "Latest …d ago →" — navigates to the newest blog post
- [ ] Click "Live Dashboard →" — navigates to `/dashboard`
- [ ] Spot-check that the existing avatar GIF hover and the orb animations still work

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_