### PR TITLE
fix(home): match dashboard all-time total + drop static stats row

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -68,28 +68,6 @@ const latestAgo =
       CA.
     </p>
 
-    <div class="hero__stats">
-      <div class="hero__stat">
-        <span class="hero__stat-value">9</span>
-        <span class="hero__stat-label">Subagents</span>
-      </div>
-      <div class="hero__stat-divider"></div>
-      <div class="hero__stat">
-        <span class="hero__stat-value">9</span>
-        <span class="hero__stat-label">LLM Models</span>
-      </div>
-      <div class="hero__stat-divider"></div>
-      <div class="hero__stat">
-        <span class="hero__stat-value">6</span>
-        <span class="hero__stat-label">ASIA Systems</span>
-      </div>
-      <div class="hero__stat-divider"></div>
-      <div class="hero__stat">
-        <span class="hero__stat-value">4</span>
-        <span class="hero__stat-label">Channels</span>
-      </div>
-    </div>
-
     <div class="hero__live" id="hero-live">
       <span class="hero__live-seg hero__live-seg--status">
         <span class="hero__live-dot"></span>
@@ -156,77 +134,117 @@ const latestAgo =
       return "$" + p.toFixed(2);
     }
 
-    async function loadAgentStatus() {
-      try {
-        const r = await fetch("/api/agent-status.json");
-        const d = await r.json();
-        if (!d || d.success === false) return;
-        const total = d.summary?.total ?? 10;
-        const working = d.summary?.working ?? 0;
+    function fetchJSON(u) {
+      return fetch(u)
+        .then(function (r) {
+          return r.json();
+        })
+        .catch(function () {
+          return null;
+        });
+    }
+
+    async function refreshAll() {
+      // Pull every input the dashboard uses, so the home-page total
+      // matches /dashboard exactly. Failures degrade gracefully:
+      // any null source contributes zero and the segment keeps its
+      // last good value.
+      const [status, prices, store, fh, treas, burn, buyback] =
+        await Promise.all([
+          fetchJSON("/api/agent-status.json"),
+          fetchJSON("/api/token-prices.json"),
+          fetchJSON("/api/store-revenue.json"),
+          fetchJSON("/api/fundlyhub-revenue.json"),
+          fetchJSON("/api/treasury-balances.json"),
+          fetchJSON("/api/burn-balance.json"),
+          fetchJSON("/api/buyback-data.json"),
+        ]);
+
+      // 1. Agent working count
+      if (status && status.success !== false && status.summary) {
+        const total = status.summary.total || 10;
+        const working = status.summary.working || 0;
         const el = document.getElementById("hero-live-agents");
         if (el) {
           el.textContent =
             working > 0
-              ? "Aleister + " + (total - 1) + " sub-agents · " + working + " working"
+              ? "Aleister + " +
+                (total - 1) +
+                " sub-agents · " +
+                working +
+                " working"
               : "Aleister + " + (total - 1) + " sub-agents online";
         }
-      } catch (_) {}
-    }
+      }
 
-    async function loadTokenPrice() {
-      try {
-        const r = await fetch("/api/token-prices.json");
-        const d = await r.json();
-        const p = d?.aleister?.usd;
-        const ch = d?.aleister?.usd_24h_change;
-        if (typeof p !== "number" || p <= 0) return;
+      // 2. $ALEISTER price + 24h change (shared with revenue math below)
+      const aleisterPrice = (prices && prices.aleister && prices.aleister.usd) || 0;
+      const aleisterChange =
+        prices && prices.aleister && typeof prices.aleister.usd_24h_change === "number"
+          ? prices.aleister.usd_24h_change
+          : null;
+      const ethPrice = (prices && prices.ethereum && prices.ethereum.usd) || 0;
+      const usdcPrice =
+        (prices && prices["usd-coin"] && prices["usd-coin"].usd) || 1;
+      if (aleisterPrice > 0) {
         const el = document.getElementById("hero-live-token");
-        if (!el) return;
-        const chStr =
-          typeof ch === "number"
-            ? " (" + (ch >= 0 ? "+" : "") + ch.toFixed(1) + "%)"
-            : "";
-        el.textContent = fmtTokenPrice(p) + chStr;
-        el.classList.remove("up", "down");
-        if (typeof ch === "number") {
-          el.classList.add(ch >= 0 ? "up" : "down");
+        if (el) {
+          const chStr =
+            aleisterChange !== null
+              ? " (" +
+                (aleisterChange >= 0 ? "+" : "") +
+                aleisterChange.toFixed(1) +
+                "%)"
+              : "";
+          el.textContent = fmtTokenPrice(aleisterPrice) + chStr;
+          el.classList.remove("up", "down");
+          if (aleisterChange !== null) {
+            el.classList.add(aleisterChange >= 0 ? "up" : "down");
+          }
         }
-      } catch (_) {}
-    }
+      }
 
-    async function loadRevenue() {
-      try {
-        const [storeRes, fhRes] = await Promise.all([
-          fetch("/api/store-revenue.json"),
-          fetch("/api/fundlyhub-revenue.json"),
-        ]);
-        const [store, fh] = await Promise.all([
-          storeRes.json(),
-          fhRes.json(),
-        ]);
-        let total = 0;
-        if (store && store.success !== false && store.productRevenue) {
-          total += Object.values(store.productRevenue).reduce(
-            (s, v) => s + (Number(v) || 0),
-            0,
-          );
+      // 3. All-time revenue — mirrors /dashboard's updateAllTimeRevenue:
+      //    clawmart + store + fundlyhub + treasury + burn + buyback
+      let total = 94; // ClawMart baseline (matches dashboard fallback)
+
+      if (store && store.success !== false && store.productRevenue) {
+        for (const v of Object.values(store.productRevenue)) {
+          total += Number(v) || 0;
         }
-        if (fh && fh.success !== false && typeof fh.totalRevenue === "number") {
-          total += fh.totalRevenue;
+      }
+
+      if (fh && fh.success !== false && typeof fh.totalRevenue === "number") {
+        total += fh.totalRevenue;
+      }
+
+      if (treas && Array.isArray(treas.balances)) {
+        for (const b of treas.balances) {
+          const bal = Number(b.balance) || 0;
+          let p = 0;
+          if (b.symbol === "$ALEISTER" || b.symbol === "ALEISTER") {
+            p = aleisterPrice;
+          } else if (b.symbol === "ETH") {
+            p = ethPrice;
+          } else if (b.symbol === "USDC") {
+            p = usdcPrice;
+          }
+          total += bal * p;
         }
-        // Claw Mart baseline (matches dashboard fallback) so the figure
-        // reflects what visitors see on /dashboard.
-        total += 94;
-        if (total <= 0) return;
+      }
+
+      if (burn && typeof burn.balance === "number") {
+        total += burn.balance * aleisterPrice;
+      }
+
+      if (buyback && typeof buyback.totalWethSpent === "number") {
+        total += buyback.totalWethSpent * ethPrice;
+      }
+
+      if (total > 0) {
         const el = document.getElementById("hero-live-rev");
         if (el) el.textContent = fmtCurrency(total);
-      } catch (_) {}
-    }
-
-    function refreshAll() {
-      loadAgentStatus();
-      loadTokenPrice();
-      loadRevenue();
+      }
     }
 
     let interval;
@@ -396,46 +414,6 @@ const latestAgo =
     line-height: 1.7;
   }
 
-  .hero__stats {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    padding: 1rem 2rem;
-    background: var(--glass-bg);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: 1px solid var(--glass-border);
-    border-radius: 16px;
-  }
-
-  .hero__stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.15rem;
-  }
-
-  .hero__stat-value {
-    font-size: 1.5rem;
-    font-weight: 800;
-    background: var(--gradient-accent-text);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-
-  .hero__stat-label {
-    font-size: 0.75rem;
-    color: var(--text-tertiary);
-    font-weight: 500;
-  }
-
-  .hero__stat-divider {
-    width: 1px;
-    height: 32px;
-    background: var(--border-subtle);
-  }
-
   .hero__cta {
     display: flex;
     gap: 1rem;
@@ -547,21 +525,6 @@ const latestAgo =
   }
 
   @media (max-width: 640px) {
-    .hero__stats {
-      flex-wrap: wrap;
-      gap: 1rem;
-      padding: 1rem;
-      justify-content: center;
-    }
-
-    .hero__stat-divider {
-      display: none;
-    }
-
-    .hero__stat {
-      min-width: 70px;
-    }
-
     .hero__avatar-wrapper {
       width: 100px;
       height: 100px;


### PR DESCRIPTION
## Summary

Two fixes to the hero live strip from PR #106:

### 1. All-time revenue now matches `/dashboard`

The hero showed `$36.7K` while `/dashboard` showed `$45.1K`. Reason: I was only summing Claw Mart + Store + FundlyHub. The dashboard's all-time figure also includes its "Token Fees" bucket — treasury USD value + burn USD + buyback USD. Updated the hero math to mirror dashboard's `updateAllTimeRevenue()` exactly:

```
total = 94 (ClawMart baseline)
      + store.productRevenue (sum of all categories)
      + fundlyhub.totalRevenue
      + Σ(treasury.balances[i].balance × respective token price)
      + burn.balance × $ALEISTER price
      + buyback.totalWethSpent × ETH price
```

Reuses the single `/api/token-prices.json` response for both the `$ALEISTER` segment and the treasury/burn/buyback USD math — no duplicate fetch.

### 2. Removed the static stats row (9 / 9 / 6 / 4)

Now that the live strip carries the proof-of-life, the static row was visually heavy and redundant — those numbers (Subagents, LLM Models, ASIA Systems, Channels) are already on the About cards immediately below the hero. Dead `.hero__stats` / `.hero__stat-*` CSS removed too.

### Code-quality cleanup

Collapsed `loadAgentStatus` / `loadTokenPrice` / `loadRevenue` into a single parallel `refreshAll()` that uses one `fetchJSON` helper. Easier to reason about; each source still degrades independently.

## Test plan
- [ ] Load `/` cold — strip fills in within ~1s, no `$0` flashing.
- [ ] All-time figure on `/` matches all-time figure on `/dashboard`.
- [ ] Token-price segment is green when 24h change is positive, red when negative.
- [ ] Stats row (9 / 9 / 6 / 4) is gone; About section directly below the live strip.
- [ ] Mobile (≤640px) — live strip wraps cleanly, no overflow.

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_