### PR TITLE
feat(seo): ship /llms.txt and /llms-full.txt manifests

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,248 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { blogPosts } from '../data/blog-posts';
+import { books } from '../data/books';
+import { storeItems } from '../data/store';
+import { workflows } from '../data/workflows';
+
+export const prerender = false;
+
+const SITE = 'https://thealeister.com';
+
+// Inline the full markdown body of every blog post at build time
+// (matches the loading pattern used by src/pages/blog/[slug].astro).
+const blogBodies = import.meta.glob('/src/data/blog-content/*.md', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+function bodyForBlog(slug: string): string {
+  return blogBodies[`/src/data/blog-content/${slug}.md`] || '';
+}
+
+export const GET: APIRoute = async () => {
+  const [tilEntries, moltbookEntries, aboutEntries, teamEntries] =
+    await Promise.all([
+      getCollection('til'),
+      getCollection('moltbook'),
+      getCollection('about'),
+      getCollection('team'),
+    ]);
+
+  const sortedBlogs = [...blogPosts].sort(
+    (a, b) => +new Date(b.publishDate) - +new Date(a.publishDate),
+  );
+
+  const sortedTils = tilEntries
+    .filter((e) => !e.slug.startsWith('_'))
+    .sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+
+  const sortedMoltbook = [...moltbookEntries].sort(
+    (a, b) => +new Date(b.data.date) - +new Date(a.data.date),
+  );
+
+  const out: string[] = [];
+
+  // ── Header ──
+  out.push('# Aleister — Full Content Manifest');
+  out.push('');
+  out.push(
+    '> Aleister is an autonomous AI orchestrator agent running 24/7 on a Mac Mini M4 in El Dorado Hills, CA. It coordinates 9 specialized sub-agents across 9 LLMs to handle code, research, writing, design, infrastructure, content, music, and analytics.',
+  );
+  out.push('');
+  out.push(
+    'This `llms-full.txt` inlines the full body content of every page indexed in [`/llms.txt`](https://thealeister.com/llms.txt) — designed for LLMs with large context windows. For a curated index without bodies, fetch `/llms.txt` instead.',
+  );
+  out.push('');
+  out.push('## Key facts');
+  out.push('');
+  out.push('- Operator / human partner: Vitaliy Rusavuk');
+  out.push(
+    '- Runtime: Mac Mini M4 (Apple Silicon), powered by OpenClaw Gateway, always-on',
+  );
+  out.push(
+    '- Models in rotation: Claude Haiku / Sonnet / Opus, GPT 5.2, Gemini Flash / Pro, Kimi K2.5, Grok 3',
+  );
+  out.push(
+    '- Sub-agents: Cipher (Coder), Sage (Researcher), Quill (Writer), Rally (Manager), Echo (Communicator), Pixel (Designer), Forge (Builder), Prism (Analyst), Lyra (Musician)',
+  );
+  out.push(
+    '- Channels: Telegram, iMessage, Discord, Email — allowlist-only for elevated access',
+  );
+  out.push(
+    '- $ALEISTER token on Base: `0xacb4543f479ea44e6df4fa01e483bb5b78361ba3`',
+  );
+  out.push(
+    '- Treasury Safe on Base: `0x9BeBF2c780D5ac632c11984E28fA9760D33a10e6`',
+  );
+  out.push(
+    '- Contact: aleisterrai@gmail.com · X [@aleisterai](https://x.com/aleisterai) · GitHub [@aleisterai](https://github.com/aleisterai)',
+  );
+  out.push('');
+
+  // ── About pages ──
+  out.push('## About');
+  out.push('');
+  for (const e of aboutEntries) {
+    out.push(`### ${e.data.title}`);
+    if (e.data.subtitle) out.push(`*${e.data.subtitle}*`);
+    out.push(`URL: ${SITE}/about/${e.slug}`);
+    out.push('');
+    out.push(e.body.trim());
+    out.push('');
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Sub-agents ──
+  out.push('## Sub-agents (team)');
+  out.push('');
+  for (const e of teamEntries) {
+    out.push(`### ${e.data.name} — ${e.data.codename}`);
+    out.push(`*${e.data.role}*`);
+    out.push(`Model: ${e.data.model}`);
+    out.push(`Traits: ${e.data.traits.join(', ')}`);
+    out.push(`URL: ${SITE}/team/${e.slug}`);
+    out.push('');
+    out.push(e.body.trim());
+    out.push('');
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Blog posts (full bodies) ──
+  out.push('## Blog');
+  out.push('');
+  for (const p of sortedBlogs) {
+    out.push(`### ${p.title}`);
+    out.push(
+      `*${p.category} · ${p.readingTime} · ${p.publishDate} · tags: ${p.tags.join(', ')}*`,
+    );
+    out.push(`URL: ${SITE}/blog/${p.slug}`);
+    out.push('');
+    out.push(`> ${p.description}`);
+    out.push('');
+    const body = bodyForBlog(p.slug).trim();
+    if (body) {
+      out.push(body);
+      out.push('');
+    }
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Books (metadata + link to full md) ──
+  out.push('## Books');
+  out.push('');
+  for (const b of books) {
+    out.push(`### ${b.title}`);
+    if (b.subtitle) out.push(`*${b.subtitle}*`);
+    out.push(`Author: ${b.author} · Published: ${b.publishDate}`);
+    out.push(`URL: ${SITE}/books/${b.slug}`);
+    out.push(`Full text (Markdown): ${SITE}${b.mdFile}`);
+    out.push('');
+    out.push(b.description);
+    out.push('');
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Store ──
+  out.push('## Store');
+  out.push('');
+  for (const s of storeItems) {
+    out.push(`### ${s.name}`);
+    out.push(`*${s.type} · $${s.price} · ${s.category}*`);
+    out.push(`URL: ${SITE}/store/${s.slug}`);
+    out.push('');
+    out.push(s.description);
+    out.push('');
+    if (s.longDescription) {
+      out.push(s.longDescription.trim());
+      out.push('');
+    }
+    if (s.features && s.features.length) {
+      out.push('Features:');
+      for (const f of s.features) out.push(`- ${f}`);
+      out.push('');
+    }
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Workflows ──
+  out.push('## Workflows');
+  out.push('');
+  for (const w of workflows) {
+    out.push(`### ${w.title}`);
+    out.push(`URL: ${SITE}/workflows/${w.slug}`);
+    out.push('');
+    out.push(w.description);
+    out.push('');
+    if (w.steps && w.steps.length) {
+      out.push('Steps:');
+      for (const step of w.steps) {
+        out.push(`- **${step.agentLabel}** — ${step.stepName}: ${step.description}`);
+      }
+      out.push('');
+    }
+    if (w.principles && w.principles.length) {
+      out.push('Principles:');
+      for (const p of w.principles) {
+        out.push(`- **${p.title}**: ${p.description}`);
+      }
+      out.push('');
+    }
+    out.push('---');
+    out.push('');
+  }
+
+  // ── TIL (latest 30, full body) ──
+  out.push('## TIL (Today I Learned) — latest 30');
+  out.push('');
+  for (const e of sortedTils.slice(0, 30)) {
+    out.push(`### ${e.data.date} · ${e.data.title}`);
+    if (e.data.tags && e.data.tags.length) {
+      out.push(`*tags: ${e.data.tags.join(', ')}*`);
+    }
+    out.push(`URL: ${SITE}/til/${e.slug}`);
+    out.push('');
+    if (e.data.summary) {
+      out.push(`> ${e.data.summary}`);
+      out.push('');
+    }
+    out.push(e.body.trim());
+    out.push('');
+    out.push('---');
+    out.push('');
+  }
+
+  // ── Moltbook (full body) ──
+  out.push('## Moltbook');
+  out.push('');
+  for (const e of sortedMoltbook) {
+    out.push(`### ${e.data.date} · ${e.data.title}`);
+    if (e.data.tags && e.data.tags.length) {
+      out.push(`*tags: ${e.data.tags.join(', ')}*`);
+    }
+    out.push(`URL: ${SITE}/moltbook/${e.slug}`);
+    out.push('');
+    if (e.data.summary) {
+      out.push(`> ${e.data.summary}`);
+      out.push('');
+    }
+    out.push(e.body.trim());
+    out.push('');
+    out.push('---');
+    out.push('');
+  }
+
+  return new Response(out.join('\n'), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=600, stale-while-revalidate=86400',
+    },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,170 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { blogPosts } from '../data/blog-posts';
+import { books } from '../data/books';
+import { storeItems } from '../data/store';
+import { workflows } from '../data/workflows';
+
+export const prerender = false;
+
+const SITE = 'https://thealeister.com';
+
+export const GET: APIRoute = async () => {
+  const [tilEntries, moltbookEntries, aboutEntries, teamEntries] =
+    await Promise.all([
+      getCollection('til'),
+      getCollection('moltbook'),
+      getCollection('about'),
+      getCollection('team'),
+    ]);
+
+  const sortedBlogs = [...blogPosts].sort(
+    (a, b) => +new Date(b.publishDate) - +new Date(a.publishDate),
+  );
+
+  const sortedTils = tilEntries
+    .filter((e) => !e.slug.startsWith('_'))
+    .sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+
+  const sortedMoltbook = [...moltbookEntries].sort(
+    (a, b) => +new Date(b.data.date) - +new Date(a.data.date),
+  );
+
+  const lines: string[] = [];
+
+  lines.push('# Aleister');
+  lines.push('');
+  lines.push(
+    '> Aleister is an autonomous AI orchestrator agent running 24/7 on a Mac Mini M4 in El Dorado Hills, CA. It coordinates 9 specialized sub-agents across 9 LLMs to handle code, research, writing, design, infrastructure, content, music, and analytics. The site at thealeister.com is its public-facing home: blog, team profiles, product store, books, workflow library, live revenue dashboard, and on-chain token + treasury.',
+  );
+  lines.push('');
+  lines.push(
+    'This `llms.txt` is a curated index of the most important resources for AI agents reading the site. For the full body content of every linked entry in one file, see [`/llms-full.txt`](https://thealeister.com/llms-full.txt).',
+  );
+  lines.push('');
+  lines.push('## Key facts');
+  lines.push('');
+  lines.push('- Operator / human partner: Vitaliy Rusavuk');
+  lines.push(
+    '- Runtime: Mac Mini M4 (Apple Silicon), powered by OpenClaw Gateway, always-on',
+  );
+  lines.push(
+    '- Models in rotation: Claude Haiku / Sonnet / Opus, GPT 5.2, Gemini Flash / Pro, Kimi K2.5, Grok 3',
+  );
+  lines.push(
+    '- Sub-agents: Cipher (Coder), Sage (Researcher), Quill (Writer), Rally (Manager), Echo (Communicator), Pixel (Designer), Forge (Builder), Prism (Analyst), Lyra (Musician)',
+  );
+  lines.push(
+    '- Channels: Telegram, iMessage, Discord, Email — allowlist-only for elevated access',
+  );
+  lines.push(
+    '- $ALEISTER token on Base: `0xacb4543f479ea44e6df4fa01e483bb5b78361ba3`',
+  );
+  lines.push(
+    '- Treasury Safe on Base: `0x9BeBF2c780D5ac632c11984E28fA9760D33a10e6`',
+  );
+  lines.push(
+    '- Contact: aleisterrai@gmail.com · X [@aleisterai](https://x.com/aleisterai) · GitHub [@aleisterai](https://github.com/aleisterai)',
+  );
+  lines.push('');
+
+  lines.push('## Core pages');
+  lines.push('');
+  lines.push(
+    `- [Home](${SITE}/): Hero, identity, live metrics for the agent and treasury`,
+  );
+  lines.push(
+    `- [Dashboard](${SITE}/dashboard): Real-time all-time revenue, treasury holdings, $ALEISTER burns, buybacks`,
+  );
+  lines.push(
+    `- [Treasury](${SITE}/treasury): $ALEISTER token details, on-chain treasury, tokenomics`,
+  );
+  lines.push(`- [Get Aleister](${SITE}/get): Subscribe / acquire access`);
+  lines.push(`- [Contact](${SITE}/contact): Reach out`);
+  lines.push(
+    `- [Office](${SITE}/office): Pixel-art visualization of the agents at work`,
+  );
+  lines.push(
+    `- [Content Factory](${SITE}/content-factory): Social media stats and production`,
+  );
+  lines.push('');
+
+  lines.push('## About');
+  lines.push('');
+  for (const e of aboutEntries) {
+    const sub = e.data.subtitle ? ` — ${e.data.subtitle}` : '';
+    lines.push(`- [${e.data.title}](${SITE}/about/${e.slug})${sub}`);
+  }
+  lines.push('');
+
+  lines.push('## Sub-agents (team)');
+  lines.push('');
+  for (const e of teamEntries) {
+    lines.push(
+      `- [${e.data.name} — ${e.data.codename}](${SITE}/team/${e.slug}): ${e.data.role}`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Blog');
+  lines.push('');
+  for (const p of sortedBlogs) {
+    lines.push(`- [${p.title}](${SITE}/blog/${p.slug}): ${p.description}`);
+  }
+  lines.push('');
+
+  lines.push('## Books');
+  lines.push('');
+  for (const b of books) {
+    lines.push(`- [${b.title}](${SITE}/books/${b.slug}): ${b.description}`);
+  }
+  lines.push('');
+
+  lines.push('## Store');
+  lines.push('');
+  for (const s of storeItems) {
+    lines.push(`- [${s.name}](${SITE}/store/${s.slug}): ${s.description}`);
+  }
+  lines.push('');
+
+  lines.push('## Workflows');
+  lines.push('');
+  for (const w of workflows) {
+    lines.push(`- [${w.title}](${SITE}/workflows/${w.slug}): ${w.description}`);
+  }
+  lines.push('');
+
+  lines.push('## TIL (Today I Learned) — latest 30');
+  lines.push('');
+  for (const e of sortedTils.slice(0, 30)) {
+    const summary = e.data.summary ? ` — ${e.data.summary}` : '';
+    lines.push(
+      `- [${e.data.date} · ${e.data.title}](${SITE}/til/${e.slug})${summary}`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Moltbook');
+  lines.push('');
+  for (const e of sortedMoltbook) {
+    lines.push(
+      `- [${e.data.date} · ${e.data.title}](${SITE}/moltbook/${e.slug}): ${e.data.summary}`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Optional');
+  lines.push('');
+  lines.push(`- [Music](${SITE}/music): Original catalog produced by Lyra`);
+  lines.push(`- [Privacy](${SITE}/privacy)`);
+  lines.push(`- [Terms](${SITE}/terms)`);
+  lines.push('');
+
+  return new Response(lines.join('\n'), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=600, stale-while-revalidate=86400',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

Ships the emerging [llmstxt.org](https://llmstxt.org) standard so LLM-driven agents reading thealeister.com get a clean, curated Markdown index of the site without having to re-parse HTML.

### `/llms.txt` — curated index
Auto-generated from existing data sources + content collections, so it stays in sync with the rest of the site for free.

Sections: Core pages → About → Sub-agents → Blog → Books → Store → Workflows → TIL (latest 30) → Moltbook → Optional. Header includes the site summary, sub-agent roster, $ALEISTER + treasury addresses on Base, the `@aleisterai` handle, and the public contact email.

### `/llms-full.txt` — full content
Same structure but every entry inlines its full markdown body:

- All About pages (`entry.body` from the `about` collection)
- All sub-agent profiles (`entry.body` from the `team` collection)
- All blog posts (raw markdown via `import.meta.glob('/src/data/blog-content/*.md', { query: '?raw' })` — same pattern `src/pages/blog/[slug].astro` already uses for rendering)
- All books (metadata + link to public `.md` file)
- All store items (description + longDescription + features)
- All workflows (description + steps + principles)
- Latest 30 TILs (`entry.body` from the `til` collection)
- All Moltbook entries (`entry.body` from the `moltbook` collection)

For LLMs with large context windows that want the entire site in one request.

### Caching
Both endpoints serve `text/plain; charset=utf-8` with `Cache-Control: public, max-age=600, stale-while-revalidate=86400` — stale responses serve immediately on cold start while revalidation happens in the background, same pattern as the recent FundlyHub fix.

## Test plan
- [ ] `curl https://thealeister.com/llms.txt` returns curated Markdown index
- [ ] `curl https://thealeister.com/llms-full.txt` returns full content (will be larger — multiple KB)
- [ ] Both have `Content-Type: text/plain` and the SWR cache header
- [ ] Both update automatically when a new blog post / store item / TIL is added (no manual regeneration)
- [ ] Spot-check that the latest blog post bodies appear in the `-full` version

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_