### PR TITLE
refactor(typography): unified type scale + font tokens across the site

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -115,7 +115,7 @@
   }
 
   .about__card-icon {
-    font-size: 2rem;
+    font-size: var(--text-4xl);
     height: 2rem;
     line-height: 1;
     display: flex;
@@ -124,18 +124,18 @@
   }
 
   .about__card h3 {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
   }
 
   .about__card p {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     line-height: 1.6;
     flex: 1;
   }
 
   .about__card-arrow {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     opacity: 0;
@@ -153,7 +153,7 @@
   }
 
   .about__sponsor-link {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     margin-top: auto;

--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -74,7 +74,7 @@ const { book, index = 0 } = Astro.props;
     }
 
     .book-card__title {
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         font-weight: 700;
         letter-spacing: -0.01em;
         line-height: 1.25;
@@ -83,7 +83,7 @@ const { book, index = 0 } = Astro.props;
     }
 
     .book-card__subtitle {
-        font-size: 0.78rem;
+        font-size: var(--text-xs);
         color: var(--text-tertiary);
         line-height: 1.4;
         margin: 0;

--- a/src/components/ClawMart.astro
+++ b/src/components/ClawMart.astro
@@ -59,7 +59,7 @@
   }
 
   .clawmart__title {
-    font-size: 1.75rem;
+    font-size: var(--text-3xl);
     font-weight: 800;
     line-height: 1.3;
     margin: 0;
@@ -69,7 +69,7 @@
     display: inline-flex;
     align-items: center;
     padding: 0.2rem 0.6rem;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     border-radius: 20px;
     background: color-mix(in srgb, var(--text-accent) 12%, transparent);
@@ -81,7 +81,7 @@
 
   .clawmart__desc {
     color: var(--text-secondary);
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     line-height: 1.6;
     margin-bottom: 1.25rem;
   }
@@ -96,7 +96,7 @@
   }
 
   .clawmart__features li {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     padding-left: 1.25rem;
     position: relative;

--- a/src/components/Feed.astro
+++ b/src/components/Feed.astro
@@ -193,7 +193,7 @@ const tweets = [
   }
 
   .feed__profile-name {
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
     font-weight: 800;
     color: var(--text-accent);
     text-decoration: none;
@@ -204,7 +204,7 @@ const tweets = [
   }
 
   .feed__profile-desc {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     line-height: 1.5;
     color: var(--text-secondary);
     white-space: pre-wrap;
@@ -225,13 +225,13 @@ const tweets = [
   }
 
   .feed__stat-val {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 800;
     color: var(--text-primary);
   }
 
   .feed__stat-label {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     font-weight: 600;
   }
@@ -268,7 +268,7 @@ const tweets = [
     display: flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     color: var(--text-tertiary);
     margin-bottom: -0.25rem;
@@ -292,7 +292,7 @@ const tweets = [
     align-items: center;
     gap: 0.4rem;
     flex: 1;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
   }
 
   .feed__post-name {
@@ -306,7 +306,7 @@ const tweets = [
 
   .feed__post-dot {
     color: var(--text-tertiary);
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
   }
 
   .feed__post-logo {
@@ -314,7 +314,7 @@ const tweets = [
   }
 
   .feed__post-body {
-    font-size: 1.05rem;
+    font-size: var(--text-lg);
     line-height: 1.5;
     color: var(--text-primary);
     white-space: pre-wrap;
@@ -332,7 +332,7 @@ const tweets = [
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     transition: color 0.2s;
   }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -184,7 +184,7 @@ const subagents = [
   }
 
   .footer__logo {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 800;
   }
 
@@ -196,7 +196,7 @@ const subagents = [
   }
 
   .footer__tagline {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
@@ -237,7 +237,7 @@ const subagents = [
   }
 
   .footer__heading {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -246,7 +246,7 @@ const subagents = [
   }
 
   .footer__email {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     margin-top: 0.25rem;
     transition: color 0.2s ease;
@@ -257,7 +257,7 @@ const subagents = [
   }
 
   .footer__email {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin-top: 0.3rem;
     display: block;
@@ -269,7 +269,7 @@ const subagents = [
   }
 
   .footer__col a {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     transition: color 0.2s ease;
   }
@@ -284,7 +284,7 @@ const subagents = [
   }
 
   .footer__meta p {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
@@ -294,7 +294,7 @@ const subagents = [
 
   .footer__ca {
     position: relative;
-    font-size: 0.72rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     margin-top: 0.35rem;
     cursor: pointer;
@@ -317,7 +317,7 @@ const subagents = [
     transform: translateX(-50%) scale(0.9);
     background: var(--text-accent);
     color: #000;
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 600;
     padding: 0.25rem 0.6rem;
     border-radius: 6px;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -178,13 +178,13 @@ const standaloneLinks = [{ label: "Dashboard", href: "/dashboard" }];
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
     font-weight: 800;
     letter-spacing: -0.03em;
   }
 
   .header__logo-icon {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
   }
 
   .header__logo-text {
@@ -203,7 +203,7 @@ const standaloneLinks = [{ label: "Dashboard", href: "/dashboard" }];
   .header__link {
     padding: 0.5rem 0.875rem;
     border-radius: 8px;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     color: var(--text-secondary);
     transition: all 0.2s ease;
@@ -314,13 +314,13 @@ const standaloneLinks = [{ label: "Dashboard", href: "/dashboard" }];
   }
 
   .header__dropdown-label {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-primary);
   }
 
   .header__dropdown-desc {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-secondary);
     line-height: 1.3;
   }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -402,14 +402,14 @@ const latestAgo =
   }
 
   .hero__title {
-    font-size: clamp(3rem, 8vw, 5.5rem);
+    font-size: var(--text-display);
     font-weight: 900;
     letter-spacing: -0.04em;
     line-height: 1.1;
   }
 
   .hero__subtitle {
-    font-size: clamp(1rem, 1.5vw, 1.2rem);
+    font-size: var(--text-lg);
     max-width: 600px;
     line-height: 1.7;
   }
@@ -434,7 +434,7 @@ const latestAgo =
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: 1px solid var(--glass-border);
     border-radius: 999px;
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-secondary);
     max-width: 100%;
   }
@@ -466,8 +466,8 @@ const latestAgo =
   }
 
   .hero__live-label {
-    font-size: 0.65rem;
-    letter-spacing: 0.06em;
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--text-tertiary);
     font-weight: 600;
@@ -501,7 +501,7 @@ const latestAgo =
     .hero__live {
       gap: 0.6rem 0.9rem;
       padding: 0.6rem 0.9rem;
-      font-size: 0.72rem;
+      font-size: var(--text-xs);
     }
     .hero__live-divider {
       display: none;

--- a/src/components/Hobbies.astro
+++ b/src/components/Hobbies.astro
@@ -53,7 +53,7 @@
   }
 
   .hobbies__heading {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 800;
     margin: 0 0 1.25rem;
   }
@@ -99,13 +99,13 @@
   }
 
   .hobbies__title {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin: 0;
   }
 
   .hobbies__desc {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
     margin: 0;
@@ -113,7 +113,7 @@
   }
 
   .hobbies__link {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     margin-top: 0.25rem;

--- a/src/components/MiniPlayer.astro
+++ b/src/components/MiniPlayer.astro
@@ -309,7 +309,7 @@
     }
 
     .mini-player__title {
-        font-size: 0.78rem;
+        font-size: var(--text-xs);
         font-weight: 600;
         color: var(--text-primary);
         white-space: nowrap;
@@ -345,9 +345,9 @@
     }
 
     .mini-player__time {
-        font-size: 0.6rem;
+        font-size: var(--text-2xs);
         color: var(--text-tertiary);
-        font-family: "JetBrains Mono", "Fira Code", monospace;
+        font-family: var(--font-mono);
         white-space: nowrap;
         min-width: 5rem;
         text-align: right;
@@ -375,7 +375,7 @@
     }
 
     .mini-player__close {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         width: 28px;
         height: 28px;
     }

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -35,9 +35,8 @@ const { title = "", accent, subtitle } = Astro.props;
     }
 
     .ph__title {
-        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
-            sans-serif;
-        font-size: clamp(2.5rem, 6vw, 4rem);
+        font-family: var(--font-sans);
+        font-size: var(--text-display);
         font-weight: 800;
         letter-spacing: -0.03em;
         line-height: 1.1;
@@ -53,9 +52,8 @@ const { title = "", accent, subtitle } = Astro.props;
     }
 
     .ph__subtitle {
-        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
-            sans-serif;
-        font-size: clamp(0.95rem, 1.2vw, 1.1rem);
+        font-family: var(--font-sans);
+        font-size: var(--text-base);
         color: var(--text-secondary);
         line-height: 1.6;
         max-width: 640px;
@@ -64,7 +62,7 @@ const { title = "", accent, subtitle } = Astro.props;
 
     @media (max-width: 480px) {
         .ph__title {
-            font-size: 2rem;
+            font-size: var(--text-4xl);
         }
     }
 </style>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -70,13 +70,13 @@ import { projects } from '../data/projects';
   }
 
   .project-card__name {
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
     font-weight: 800;
     flex: 1;
   }
 
   .project-card__arrow {
-    font-size: 1.2rem;
+    font-size: var(--text-xl);
     color: var(--text-tertiary);
     transition: all 0.3s ease;
   }
@@ -87,13 +87,13 @@ import { projects } from '../data/projects';
   }
 
   .project-card__role {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
   }
 
   .project-card__desc {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     line-height: 1.6;
   }
 

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -31,7 +31,7 @@
   }
 
   .services__heading {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     font-weight: 800;
     margin: 0 0 1.25rem;
   }
@@ -51,13 +51,13 @@
   }
 
   .services__title {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin: 0;
   }
 
   .services__desc {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
     margin: 0;
@@ -65,7 +65,7 @@
   }
 
   .services__link {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     margin-top: 0.25rem;

--- a/src/components/Subagents.astro
+++ b/src/components/Subagents.astro
@@ -100,19 +100,19 @@ const subagents = teamMembers;
   }
 
   .subagent-card__name {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 700;
     line-height: 1.2;
   }
 
   .subagent-card__role {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     font-weight: 500;
   }
 
   .subagent-card__desc {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     line-height: 1.6;
     flex: 1;
     overflow: hidden;
@@ -133,7 +133,7 @@ const subagents = teamMembers;
     align-items: center;
     padding: 0.2rem 0.6rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: color-mix(in srgb, var(--trait-color) 15%, transparent);
     color: var(--trait-color);
@@ -156,7 +156,7 @@ const subagents = teamMembers;
   }
 
   .subagent-card__view {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     margin-top: 0.25rem;
     opacity: 0;

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -56,7 +56,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__back {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         transition: color 0.2s ease;
     }
@@ -66,7 +66,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__title {
-        font-size: clamp(1.5rem, 3vw, 2.25rem);
+        font-size: var(--text-4xl);
         margin-bottom: 0.25rem;
         max-width: 1200px;
         margin-left: auto;
@@ -74,7 +74,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__subtitle {
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         color: var(--text-tertiary);
         margin-bottom: 2rem;
         max-width: 1200px;
@@ -89,7 +89,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__content :global(h2) {
-        font-size: 1.5rem;
+        font-size: var(--text-2xl);
         margin-top: 2.5rem;
         margin-bottom: 1rem;
         padding-bottom: 0.5rem;
@@ -97,7 +97,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__content :global(h3) {
-        font-size: 1.15rem;
+        font-size: var(--text-lg);
         margin-top: 1.5rem;
         margin-bottom: 0.75rem;
     }
@@ -129,7 +129,7 @@ const { Content } = await entry.render();
     }
 
     .about-entry__content :global(code) {
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         font-size: 0.85em;
         padding: 0.15rem 0.4rem;
         border-radius: 4px;
@@ -152,7 +152,7 @@ const { Content } = await entry.render();
         border: none;
         background: none;
         color: #e2e8f0;
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
         line-height: 1.6;
     }
 
@@ -178,7 +178,7 @@ const { Content } = await entry.render();
         width: 100%;
         border-collapse: collapse;
         margin-bottom: 1.5rem;
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
     }
 
     .about-entry__content :global(th) {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -87,7 +87,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__back {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         transition: color 0.2s ease;
     }
@@ -111,7 +111,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__category {
-        font-size: 0.7rem;
+        font-size: var(--text-2xs);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.1em;
@@ -123,19 +123,19 @@ const categoryColors: Record<string, string> = {
 
     .blog-post__time,
     .blog-post__date {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
     }
 
     .blog-post__title {
-        font-size: clamp(1.75rem, 4vw, 2.75rem);
+        font-size: var(--text-5xl);
         font-weight: 800;
         letter-spacing: -0.02em;
         line-height: 1.15;
     }
 
     .blog-post__desc {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         color: var(--text-secondary);
         line-height: 1.6;
         margin: 0;
@@ -161,7 +161,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__content :global(h1) {
-        font-size: clamp(1.5rem, 3vw, 2rem);
+        font-size: var(--text-4xl);
         margin-top: 3rem;
         margin-bottom: 1rem;
         padding-bottom: 0.5rem;
@@ -169,7 +169,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__content :global(h2) {
-        font-size: clamp(1.25rem, 2.5vw, 1.65rem);
+        font-size: var(--text-3xl);
         margin-top: 2.5rem;
         margin-bottom: 0.75rem;
         padding-bottom: 0.4rem;
@@ -177,7 +177,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__content :global(h3) {
-        font-size: clamp(1.05rem, 2vw, 1.3rem);
+        font-size: var(--text-xl);
         margin-top: 1.75rem;
         margin-bottom: 0.5rem;
     }
@@ -185,7 +185,7 @@ const categoryColors: Record<string, string> = {
     .blog-post__content :global(p) {
         margin-bottom: 1.15rem;
         line-height: 1.8;
-        font-size: 1rem;
+        font-size: var(--text-base);
     }
 
     .blog-post__content :global(ul),
@@ -210,7 +210,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-post__content :global(code) {
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         font-size: 0.85em;
         padding: 0.15rem 0.4rem;
         border-radius: 4px;
@@ -234,7 +234,7 @@ const categoryColors: Record<string, string> = {
         border: none;
         background: none;
         color: var(--text-primary);
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
     }
 
     .blog-post__content :global(a) {
@@ -267,7 +267,7 @@ const categoryColors: Record<string, string> = {
         width: 100%;
         border-collapse: collapse;
         margin-bottom: 1.75rem;
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
     }
 
     .blog-post__content :global(th) {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -107,7 +107,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-card__category {
-        font-size: 0.7rem;
+        font-size: var(--text-2xs);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.1em;
@@ -118,12 +118,12 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-card__time {
-        font-size: 0.75rem;
+        font-size: var(--text-xs);
         color: var(--text-tertiary);
     }
 
     .blog-card__title {
-        font-size: clamp(1.1rem, 2vw, 1.35rem);
+        font-size: var(--text-xl);
         font-weight: 800;
         letter-spacing: -0.02em;
         line-height: 1.25;
@@ -131,7 +131,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-card__desc {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.6;
         margin: 0;
@@ -157,7 +157,7 @@ const categoryColors: Record<string, string> = {
     }
 
     .blog-card__date {
-        font-size: 0.75rem;
+        font-size: var(--text-xs);
         color: var(--text-tertiary);
         white-space: nowrap;
     }

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -355,7 +355,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__back {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         transition: color 0.2s ease;
     }
@@ -365,7 +365,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__download {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         padding: 0.6rem 1.25rem;
         gap: 0.4rem;
         border-radius: 10px;
@@ -405,14 +405,14 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__title {
-        font-size: clamp(1.5rem, 3vw, 2.25rem);
+        font-size: var(--text-4xl);
         font-weight: 800;
         letter-spacing: -0.02em;
         line-height: 1.15;
     }
 
     .book-detail__subtitle {
-        font-size: 1rem;
+        font-size: var(--text-base);
         color: var(--text-accent);
         font-style: italic;
         font-weight: 500;
@@ -420,7 +420,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__author {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
         font-weight: 600;
         margin: 0;
@@ -433,14 +433,14 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__desc {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.6;
         margin: 0;
     }
 
     .book-detail__date {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         color: var(--text-accent);
         font-weight: 600;
     }
@@ -458,7 +458,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__content :global(h1) {
-        font-size: clamp(1.75rem, 3vw, 2.5rem);
+        font-size: var(--text-4xl);
         margin-top: 3.5rem;
         margin-bottom: 1.25rem;
         padding-bottom: 0.75rem;
@@ -466,7 +466,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__content :global(h2) {
-        font-size: clamp(1.35rem, 2.5vw, 1.85rem);
+        font-size: var(--text-3xl);
         margin-top: 3rem;
         margin-bottom: 1rem;
         padding-bottom: 0.5rem;
@@ -474,13 +474,13 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__content :global(h3) {
-        font-size: clamp(1.1rem, 2vw, 1.4rem);
+        font-size: var(--text-3xl);
         margin-top: 2rem;
         margin-bottom: 0.75rem;
     }
 
     .book-detail__content :global(h4) {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         margin-top: 1.5rem;
         margin-bottom: 0.5rem;
         color: var(--text-accent);
@@ -489,7 +489,7 @@ for (const entry of tocEntries) {
     .book-detail__content :global(p) {
         margin-bottom: 1.15rem;
         line-height: 1.8;
-        font-size: 1rem;
+        font-size: var(--text-base);
     }
 
     .book-detail__content :global(ul),
@@ -514,7 +514,7 @@ for (const entry of tocEntries) {
     }
 
     .book-detail__content :global(code) {
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         font-size: 0.85em;
         padding: 0.15rem 0.4rem;
         border-radius: 4px;
@@ -538,7 +538,7 @@ for (const entry of tocEntries) {
         border: none;
         background: none;
         color: var(--text-primary);
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
     }
 
     .book-detail__content :global(a) {
@@ -571,7 +571,7 @@ for (const entry of tocEntries) {
         width: 100%;
         border-collapse: collapse;
         margin-bottom: 1.75rem;
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
     }
 
     .book-detail__content :global(th) {
@@ -626,7 +626,7 @@ for (const entry of tocEntries) {
         -webkit-backdrop-filter: blur(20px);
         color: var(--text-primary);
         font-family: inherit;
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         font-weight: 600;
         cursor: pointer;
         box-shadow: var(--shadow-lg);
@@ -676,7 +676,7 @@ for (const entry of tocEntries) {
     }
 
     .toc-fab__heading {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.1em;
@@ -719,7 +719,7 @@ for (const entry of tocEntries) {
     .toc-fab__link {
         display: block;
         padding: 0.45rem 1.25rem;
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.4;
         transition: all 0.15s ease;
@@ -729,7 +729,7 @@ for (const entry of tocEntries) {
     .toc-fab__item--l1 .toc-fab__link {
         font-weight: 600;
         color: var(--text-primary);
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
     }
 
     .toc-fab__link:hover {
@@ -791,15 +791,15 @@ for (const entry of tocEntries) {
         display: flex;
         align-items: center;
         gap: 0.35rem;
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         white-space: nowrap;
     }
 
     .chapter-progress__current {
         font-weight: 800;
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         color: var(--text-accent);
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         min-width: 1.2em;
         text-align: center;
     }
@@ -812,7 +812,7 @@ for (const entry of tocEntries) {
     .chapter-progress__total {
         font-weight: 700;
         color: var(--text-primary);
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
     }
 
     .chapter-progress__label {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -209,7 +209,7 @@ const aleisterChannels = [
   }
 
   .operator-title {
-    font-size: clamp(1.25rem, 2.5vw, 1.5rem);
+    font-size: var(--text-xl);
     margin-top: 3rem;
     margin-bottom: 0;
   }
@@ -224,7 +224,7 @@ const aleisterChannels = [
   }
 
   .contact-card__icon {
-    font-size: 1.6rem;
+    font-size: var(--text-2xl);
     flex-shrink: 0;
     width: 44px;
     height: 44px;
@@ -238,7 +238,7 @@ const aleisterChannels = [
 
   .contact-card__label {
     display: block;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-primary);
     margin-bottom: 0.15rem;
@@ -246,9 +246,9 @@ const aleisterChannels = [
 
   .contact-card__handle {
     display: block;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
-    font-family: "JetBrains Mono", monospace;
+    font-family: var(--font-mono);
   }
 
   /* ─── About Card ─── */
@@ -257,12 +257,12 @@ const aleisterChannels = [
   }
 
   .about-card h2 {
-    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-size: var(--text-4xl);
     margin-bottom: 1rem;
   }
 
   .about-card p {
-    font-size: 0.92rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.75;
     margin-bottom: 0.75rem;
@@ -286,7 +286,7 @@ const aleisterChannels = [
 
   .faq-question {
     font-weight: 600;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     padding: 0.25rem 0;
     list-style: none;
     display: flex;
@@ -298,7 +298,7 @@ const aleisterChannels = [
 
   .faq-question::after {
     content: "＋";
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     color: var(--text-accent);
     flex-shrink: 0;
     transition: transform 0.2s ease;
@@ -310,7 +310,7 @@ const aleisterChannels = [
 
   .faq-answer {
     margin-top: 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.7;
   }

--- a/src/pages/content-factory.astro
+++ b/src/pages/content-factory.astro
@@ -159,7 +159,7 @@ import PageHeader from "../components/PageHeader.astro";
     display: inline-flex;
     align-items: center;
     gap: .5rem;
-    font-size: .95rem;
+    font-size: var(--text-base);
     color: var(--text-muted);
     margin-top: .5rem;
   }
@@ -257,7 +257,7 @@ import PageHeader from "../components/PageHeader.astro";
   .cf-card__title-area { flex: 1; min-width: 0; }
 
   .cf-card__title {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0;
@@ -265,7 +265,7 @@ import PageHeader from "../components/PageHeader.astro";
   }
 
   .cf-card__handle {
-    font-size: .8rem;
+    font-size: var(--text-sm);
     color: var(--text-muted);
     text-decoration: none;
     transition: color .2s;
@@ -294,7 +294,7 @@ import PageHeader from "../components/PageHeader.astro";
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: .7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     color: var(--text-muted);
     background: var(--glass-bg, rgba(255,255,255,.04));
@@ -314,7 +314,7 @@ import PageHeader from "../components/PageHeader.astro";
 
   .cf-stat__value {
     display: block;
-    font-size: 1.35rem;
+    font-size: var(--text-xl);
     font-weight: 800;
     color: var(--text-primary);
     line-height: 1.3;
@@ -323,7 +323,7 @@ import PageHeader from "../components/PageHeader.astro";
 
   .cf-stat__label {
     display: block;
-    font-size: .7rem;
+    font-size: var(--text-2xs);
     text-transform: uppercase;
     letter-spacing: .06em;
     color: var(--text-muted);
@@ -333,7 +333,7 @@ import PageHeader from "../components/PageHeader.astro";
   /* ── Status Bar ── */
   .cf-card__status {
     padding-top: .75rem;
-    font-size: .75rem;
+    font-size: var(--text-xs);
     color: var(--text-muted);
     text-align: center;
   }
@@ -369,7 +369,7 @@ import PageHeader from "../components/PageHeader.astro";
     background: var(--glass-bg, rgba(255,255,255,.03));
     border: 1px solid var(--glass-border, rgba(255,255,255,.06));
     border-radius: 12px;
-    font-size: .8rem;
+    font-size: var(--text-sm);
     color: var(--text-muted);
   }
 
@@ -382,7 +382,7 @@ import PageHeader from "../components/PageHeader.astro";
     border-radius: 8px;
     background: transparent;
     color: var(--text-muted);
-    font-size: .8rem;
+    font-size: var(--text-sm);
     cursor: pointer;
     transition: all .2s;
   }

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -248,8 +248,8 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .dashboard-chain {
-      font-size: 0.72rem;
-      font-family: "JetBrains Mono", monospace;
+      font-size: var(--text-xs);
+      font-family: var(--font-mono);
       text-transform: uppercase;
       letter-spacing: 0.08em;
       color: var(--text-tertiary);
@@ -269,7 +269,7 @@ const CLAW_MART_EARNINGS = 94;
       gap: 0.5rem;
       padding: 0.7rem 1.25rem;
       border-radius: 10px;
-      font-size: 0.88rem;
+      font-size: var(--text-sm);
       font-weight: 700;
       background: var(--bg-glass);
       border: 1px solid var(--border-glass);
@@ -308,14 +308,14 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .stat-label {
-      font-size: 0.8rem;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text-secondary);
       margin-bottom: 0.5rem;
     }
 
     .stat-value {
-      font-size: 1.8rem;
+      font-size: var(--text-3xl);
       font-weight: 800;
       color: var(--text-primary);
       line-height: 1;
@@ -323,7 +323,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .stat-change {
-      font-size: 0.75rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text-tertiary);
     }
@@ -354,7 +354,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .section-title {
-      font-size: 0.7rem;
+      font-size: var(--text-2xs);
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.08em;
@@ -364,7 +364,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .section-title__link {
-      font-size: 0.65rem;
+      font-size: var(--text-2xs);
       font-weight: 500;
       color: var(--accent, #6c5ce7);
       text-decoration: none;
@@ -404,7 +404,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .revenue-card__icon {
-      font-size: 1.6rem;
+      font-size: var(--text-2xl);
       line-height: 1;
       flex-shrink: 0;
       padding-top: 0.1rem;
@@ -416,14 +416,14 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .revenue-card__name {
-      font-size: 0.78rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text-secondary);
       margin-bottom: 0.35rem;
     }
 
     .revenue-card__amount {
-      font-size: 1.4rem;
+      font-size: var(--text-2xl);
       font-weight: 800;
       color: var(--text-primary);
       line-height: 1;
@@ -431,7 +431,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .revenue-card__sub {
-      font-size: 0.7rem;
+      font-size: var(--text-2xs);
       color: var(--text-tertiary);
       font-style: italic;
     }
@@ -447,7 +447,7 @@ const CLAW_MART_EARNINGS = 94;
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
-      font-size: 0.7rem;
+      font-size: var(--text-2xs);
       padding: 0.15rem 0.5rem;
       border-radius: 99px;
       background: var(--bg-glass);
@@ -484,13 +484,13 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .token-symbol {
-      font-size: 0.9rem;
+      font-size: var(--text-sm);
       font-weight: 700;
       color: var(--text-primary);
     }
 
     .token-change {
-      font-size: 0.75rem;
+      font-size: var(--text-xs);
       font-weight: 700;
       padding: 0.2rem 0.5rem;
       border-radius: 4px;
@@ -507,7 +507,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .token-balance {
-      font-size: 1.25rem;
+      font-size: var(--text-xl);
       font-weight: 800;
       color: var(--text-primary);
       line-height: 1;
@@ -515,13 +515,13 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .token-value {
-      font-size: 0.85rem;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text-secondary);
     }
 
     .token-breakdown {
-      font-size: 0.7rem;
+      font-size: var(--text-2xs);
       color: var(--text-tertiary);
       margin-top: 0.25rem;
       font-style: italic;
@@ -536,15 +536,15 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .address-label {
-      font-size: 0.8rem;
+      font-size: var(--text-sm);
       font-weight: 600;
       color: var(--text-secondary);
       margin-bottom: 0.5rem;
     }
 
     .address-value {
-      font-family: "JetBrains Mono", monospace;
-      font-size: 0.78rem;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
       color: var(--text-primary);
       word-break: break-all;
       line-height: 1.6;
@@ -566,7 +566,7 @@ const CLAW_MART_EARNINGS = 94;
       gap: 0.3rem;
       padding: 0.3rem 0.7rem;
       border-radius: 6px;
-      font-size: 0.75rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       background: var(--bg-glass);
       border: 1px solid var(--border-glass);
@@ -592,7 +592,7 @@ const CLAW_MART_EARNINGS = 94;
       align-items: center;
       padding: 0.3rem 0.7rem;
       border-radius: 6px;
-      font-size: 0.75rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       background: color-mix(in srgb, var(--text-accent) 10%, transparent);
       border: 1px solid color-mix(in srgb, var(--text-accent) 20%, transparent);
@@ -677,7 +677,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .burn-card__icon {
-      font-size: 2.2rem;
+      font-size: var(--text-4xl);
       line-height: 1;
       flex-shrink: 0;
       animation: burn-pulse 2.5s ease-in-out infinite;
@@ -694,14 +694,14 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .burn-card__label {
-      font-size: 0.78rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text-secondary);
       margin-bottom: 0.4rem;
     }
 
     .burn-card__amount {
-      font-size: 1.8rem;
+      font-size: var(--text-3xl);
       font-weight: 800;
       color: var(--text-primary);
       line-height: 1;
@@ -709,13 +709,13 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .burn-card__sub {
-      font-size: 0.72rem;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       font-style: italic;
     }
 
     .burn-card__usd {
-      font-size: 1.1rem;
+      font-size: var(--text-lg);
       font-weight: 700;
       color: #f97316;
       white-space: nowrap;
@@ -752,7 +752,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .buyback-card__icon {
-      font-size: 2.2rem;
+      font-size: var(--text-4xl);
       line-height: 1;
       flex-shrink: 0;
     }
@@ -763,14 +763,14 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .buyback-card__label {
-      font-size: 0.78rem;
+      font-size: var(--text-xs);
       font-weight: 600;
       color: var(--text-secondary);
       margin-bottom: 0.4rem;
     }
 
     .buyback-card__amount {
-      font-size: 1.8rem;
+      font-size: var(--text-3xl);
       font-weight: 800;
       color: var(--text-primary);
       line-height: 1;
@@ -778,7 +778,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .buyback-card__sub {
-      font-size: 0.72rem;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       font-style: italic;
     }
@@ -794,8 +794,8 @@ const CLAW_MART_EARNINGS = 94;
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      font-size: 0.7rem;
-      font-family: "JetBrains Mono", monospace;
+      font-size: var(--text-2xs);
+      font-family: var(--font-mono);
       color: var(--text-secondary);
     }
 
@@ -813,7 +813,7 @@ const CLAW_MART_EARNINGS = 94;
     }
 
     .buyback-card__usd {
-      font-size: 1.1rem;
+      font-size: var(--text-lg);
       font-weight: 700;
       color: #6c5ce7;
       white-space: nowrap;
@@ -823,7 +823,7 @@ const CLAW_MART_EARNINGS = 94;
     /* ──── Disclaimer ──── */
     .dashboard-disclaimer {
       margin-top: 2rem;
-      font-size: 0.75rem;
+      font-size: var(--text-xs);
       color: var(--text-tertiary);
       line-height: 1.65;
       border-left: 2px solid var(--border-subtle);
@@ -855,11 +855,11 @@ const CLAW_MART_EARNINGS = 94;
 
     @media (max-width: 480px) {
       .page-header__title {
-        font-size: 2rem;
+        font-size: var(--text-4xl);
       }
 
       .stat-value {
-        font-size: 1.5rem;
+        font-size: var(--text-2xl);
       }
     }
   </style>
@@ -1180,7 +1180,7 @@ const CLAW_MART_EARNINGS = 94;
       position: fixed; top: 20px; right: 20px;
       background: var(--gradient-accent); color: white;
       padding: 8px 16px; border-radius: 20px;
-      font-size: 0.8rem; font-weight: 600;
+      font-size: var(--text-sm); font-weight: 600;
       z-index: 1000; display: none;
       box-shadow: var(--shadow-md);
     `;

--- a/src/pages/get.astro
+++ b/src/pages/get.astro
@@ -409,7 +409,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     display: inline-block;
     padding: 0.3rem 0.9rem;
     border-radius: 999px;
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     background: color-mix(in srgb, var(--text-accent) 12%, transparent);
     color: var(--text-accent);
@@ -418,7 +418,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   }
 
   .get-hero__title {
-    font-size: clamp(2rem, 5vw, 3.5rem);
+    font-size: var(--text-5xl);
     font-weight: 800;
     line-height: 1.15;
     margin-bottom: 1.25rem;
@@ -428,7 +428,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   }
 
   .get-hero__subtitle {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     color: var(--text-secondary);
     max-width: 640px;
     margin: 0 auto 2.5rem;
@@ -445,11 +445,11 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
   .btn-lg {
     padding: 0.75rem 1.75rem;
-    font-size: 1rem;
+    font-size: var(--text-base);
   }
 
   .get-hero__note {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
@@ -468,17 +468,17 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   }
 
   .included-card__icon {
-    font-size: 1.8rem;
+    font-size: var(--text-3xl);
     margin-bottom: 0.25rem;
   }
 
   .included-card h3 {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 700;
   }
 
   .included-card p {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
   }
@@ -494,7 +494,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   .compare-table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     background: var(--bg-glass);
     backdrop-filter: blur(12px);
   }
@@ -510,7 +510,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   .compare-table thead th {
     background: color-mix(in srgb, var(--bg-glass) 80%, transparent);
     font-weight: 700;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     border-bottom: 2px solid var(--border-glass);
   }
 
@@ -560,7 +560,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     height: 32px;
     border-radius: 50%;
     background: linear-gradient(135deg, #7c3aed, #db2777);
-    font-size: 1rem;
+    font-size: var(--text-base);
     flex-shrink: 0;
   }
 
@@ -579,7 +579,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     display: inline-block;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    font-size: 0.68rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     background: var(--text-accent);
     color: white;
@@ -602,7 +602,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
   .faq-question {
     font-weight: 600;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     padding: 0.25rem 0;
     list-style: none;
     display: flex;
@@ -614,7 +614,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
   .faq-question::after {
     content: "＋";
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     color: var(--text-accent);
     flex-shrink: 0;
     transition: transform 0.2s ease;
@@ -626,7 +626,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
   .faq-answer {
     margin-top: 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.7;
   }
@@ -649,13 +649,13 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
   }
 
   .final-cta-card h2 {
-    font-size: clamp(1.75rem, 3vw, 2.5rem);
+    font-size: var(--text-4xl);
     margin-bottom: 1rem;
   }
 
   .final-cta-card p {
     color: var(--text-secondary);
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     line-height: 1.7;
     margin-bottom: 2rem;
     max-width: 520px;
@@ -665,7 +665,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
   .final-cta-note {
     margin-top: 1rem !important;
-    font-size: 0.8rem !important;
+    font-size: var(--text-sm) !important;
     color: var(--text-tertiary) !important;
     margin-bottom: 0 !important;
   }
@@ -682,7 +682,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
       grid-template-columns: 1fr;
     }
     .compare-table {
-      font-size: 0.8rem;
+      font-size: var(--text-sm);
     }
     .compare-table th,
     .compare-table td {

--- a/src/pages/lead-arbitrage.astro
+++ b/src/pages/lead-arbitrage.astro
@@ -1281,7 +1281,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-hero__title {
-        font-size: clamp(2rem, 5vw, 3.5rem);
+        font-size: var(--text-5xl);
         font-weight: 800;
         line-height: 1.15;
         margin-bottom: 1.25rem;
@@ -1291,7 +1291,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-hero__subtitle {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         color: var(--text-secondary);
         max-width: 660px;
         margin: 0 0 2.5rem;
@@ -1318,7 +1318,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-hero__stat-value {
-        font-size: 2rem;
+        font-size: var(--text-4xl);
         font-weight: 800;
         background: var(--gradient-accent-text);
         -webkit-background-clip: text;
@@ -1327,7 +1327,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-hero__stat-label {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
         font-weight: 500;
         text-transform: uppercase;
@@ -1384,17 +1384,17 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .advantage-card__icon {
-        font-size: 1.8rem;
+        font-size: var(--text-2xl);
         margin-bottom: 0.25rem;
     }
 
     .advantage-card h3 {
-        font-size: 1rem;
+        font-size: var(--text-base);
         font-weight: 700;
     }
 
     .advantage-card p {
-        font-size: 0.875rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.6;
     }
@@ -1443,7 +1443,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
         transform: translateX(-50%);
         padding: 0.2rem 0.9rem;
         border-radius: 999px;
-        font-size: 0.7rem;
+        font-size: var(--text-2xs);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.06em;
@@ -1465,13 +1465,13 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .pricing-card__name {
-        font-size: 1.15rem;
+        font-size: var(--text-lg);
         font-weight: 700;
         margin-bottom: 0.35rem;
     }
 
     .pricing-card__desc {
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
         line-height: 1.5;
     }
@@ -1484,20 +1484,20 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .pricing-card__amount {
-        font-size: 2.5rem;
+        font-size: var(--text-4xl);
         font-weight: 800;
         letter-spacing: -0.03em;
         color: var(--text-primary);
     }
 
     .pricing-card__period {
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
         font-weight: 500;
     }
 
     .pricing-card__commission {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         color: var(--text-accent);
         font-weight: 600;
         margin-bottom: 1.5rem;
@@ -1516,7 +1516,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .pricing-card__features li {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         display: flex;
         align-items: flex-start;
@@ -1534,7 +1534,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     .pricing-card__cta {
         width: 100%;
         justify-content: center;
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         padding: 0.75rem 1.5rem;
     }
 
@@ -1552,17 +1552,17 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .guarantee-card__icon {
-        font-size: 3rem;
+        font-size: var(--text-5xl);
         margin-bottom: 1rem;
     }
 
     .guarantee-card h2 {
-        font-size: clamp(1.5rem, 3vw, 2rem);
+        font-size: var(--text-4xl);
         margin-bottom: 1rem;
     }
 
     .guarantee-card p {
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         color: var(--text-secondary);
         line-height: 1.7;
         max-width: 560px;
@@ -1583,7 +1583,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     .compare-table {
         width: 100%;
         border-collapse: collapse;
-        font-size: 0.875rem;
+        font-size: var(--text-sm);
         background: var(--bg-glass);
         backdrop-filter: blur(12px);
     }
@@ -1599,7 +1599,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     .compare-table thead th {
         background: color-mix(in srgb, var(--bg-glass) 80%, transparent);
         font-weight: 700;
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         border-bottom: 2px solid var(--border-glass);
     }
 
@@ -1635,7 +1635,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .compare-total {
-        font-size: 1rem;
+        font-size: var(--text-base);
     }
 
     .compare-header {
@@ -1654,7 +1654,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
         display: inline-block;
         padding: 0.15rem 0.5rem;
         border-radius: 999px;
-        font-size: 0.68rem;
+        font-size: var(--text-2xs);
         font-weight: 700;
         background: var(--status-active);
         color: #fff;
@@ -1677,7 +1677,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .how-card__step {
-        font-size: 2rem;
+        font-size: var(--text-4xl);
         font-weight: 800;
         background: var(--gradient-accent-text);
         -webkit-background-clip: text;
@@ -1687,19 +1687,19 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .how-card h3 {
-        font-size: 1rem;
+        font-size: var(--text-base);
         font-weight: 700;
         margin-bottom: 0.5rem;
     }
 
     .how-card p {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.6;
     }
 
     .how-arrow {
-        font-size: 1.5rem;
+        font-size: var(--text-2xl);
         color: var(--text-tertiary);
         flex-shrink: 0;
     }
@@ -1719,7 +1719,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
     .faq-question {
         font-weight: 600;
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         padding: 0.25rem 0;
         list-style: none;
         display: flex;
@@ -1731,7 +1731,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
     .faq-question::after {
         content: "＋";
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         color: var(--text-accent);
         flex-shrink: 0;
         transition: transform 0.2s ease;
@@ -1743,7 +1743,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
     .faq-answer {
         margin-top: 0.75rem;
-        font-size: 0.875rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.7;
     }
@@ -1771,24 +1771,24 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .compare-mobile__emoji {
-        font-size: 2rem;
+        font-size: var(--text-4xl);
     }
 
     .compare-mobile__label {
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         font-weight: 600;
         color: var(--text-secondary);
     }
 
     .compare-mobile__cost {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         font-weight: 800;
         text-align: center;
         line-height: 1.2;
     }
 
     .compare-mobile__cost small {
-        font-size: 0.7rem;
+        font-size: var(--text-2xs);
         font-weight: 500;
         color: var(--text-tertiary);
     }
@@ -1803,7 +1803,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .compare-mobile__divider {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         font-weight: 700;
         color: var(--text-tertiary);
         text-transform: uppercase;
@@ -1827,7 +1827,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .compare-mobile__card h4 {
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         font-weight: 700;
         margin-bottom: 0.75rem;
         color: var(--text-primary);
@@ -1838,7 +1838,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
         justify-content: space-between;
         align-items: center;
         padding: 0.4rem 0;
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         border-top: 1px solid var(--glass-border);
     }
 
@@ -1859,7 +1859,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
     /* ─── Disclaimers ─── */
     .section-disclaimer {
-        font-size: 0.75rem;
+        font-size: var(--text-xs);
         color: var(--text-tertiary);
         margin-top: 2rem;
         padding-bottom: 0.5rem;
@@ -1885,17 +1885,17 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .security-card__icon {
-        font-size: 2.5rem;
+        font-size: var(--text-4xl);
         margin-bottom: 1rem;
     }
 
     .security-card h3 {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         margin-bottom: 0.75rem;
     }
 
     .security-card p {
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.65;
     }
@@ -1911,14 +1911,14 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .final-cta-card h2 {
-        font-size: clamp(1.75rem, 3vw, 2.5rem);
+        font-size: var(--text-4xl);
         margin-bottom: 1rem;
         line-height: 1.3;
     }
 
     .final-cta-card p {
         color: var(--text-secondary);
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         line-height: 1.7;
         margin-bottom: 2rem;
         max-width: 540px;
@@ -1926,12 +1926,12 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
 
     .btn-lg {
         padding: 0.75rem 1.75rem;
-        font-size: 1rem;
+        font-size: var(--text-base);
     }
 
     .final-cta-note {
         margin-top: 1rem !important;
-        font-size: 0.8rem !important;
+        font-size: var(--text-sm) !important;
         color: var(--text-tertiary) !important;
         margin-bottom: 0 !important;
     }
@@ -1955,11 +1955,11 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .niche-icon {
-        font-size: 1.6rem;
+        font-size: var(--text-2xl);
     }
 
     .niche-label {
-        font-size: 0.78rem;
+        font-size: var(--text-xs);
         font-weight: 600;
         color: var(--text-secondary);
     }
@@ -2035,7 +2035,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
             height: 1px;
         }
         .compare-table {
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
         }
         .compare-table th,
         .compare-table td {
@@ -2069,19 +2069,19 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-success__icon {
-        font-size: 4rem;
+        font-size: var(--text-display);
         margin-bottom: 1rem;
     }
 
     .la-success-card h2 {
-        font-size: 1.75rem;
+        font-size: var(--text-3xl);
         font-weight: 800;
         margin-bottom: 1rem;
     }
 
     .la-success-card p {
         color: var(--text-secondary);
-        font-size: 0.95rem;
+        font-size: var(--text-base);
         line-height: 1.7;
         margin-bottom: 2rem;
     }
@@ -2148,7 +2148,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
         right: 1rem;
         background: none;
         border: none;
-        font-size: 1.5rem;
+        font-size: var(--text-2xl);
         color: var(--text-secondary);
         cursor: pointer;
         line-height: 1;
@@ -2161,13 +2161,13 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-modal__title {
-        font-size: 1.4rem;
+        font-size: var(--text-2xl);
         font-weight: 700;
         margin-bottom: 0.35rem;
     }
 
     .la-modal__subtitle {
-        font-size: 0.88rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         margin-bottom: 1.5rem;
     }
@@ -2185,7 +2185,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
     }
 
     .la-modal__field label {
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         font-weight: 600;
         color: var(--text-secondary);
     }
@@ -2203,7 +2203,7 @@ import BreadcrumbSchema from "../components/BreadcrumbSchema.astro";
         background: var(--glass-bg);
         color: var(--text-primary);
         font-family: inherit;
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         transition: border-color 0.2s;
         outline: none;
     }

--- a/src/pages/moltbook/[...slug].astro
+++ b/src/pages/moltbook/[...slug].astro
@@ -60,7 +60,7 @@ const { Content } = await render(post);
 
   .back-link {
     display: inline-block;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
     margin-bottom: 1.5rem;
@@ -84,7 +84,7 @@ const { Content } = await render(post);
   }
 
   .post-date {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
   }
@@ -96,7 +96,7 @@ const { Content } = await render(post);
   }
 
   .post-title {
-    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-size: var(--text-4xl);
     font-weight: 800;
     letter-spacing: -0.02em;
     line-height: 1.2;
@@ -104,7 +104,7 @@ const { Content } = await render(post);
   }
 
   .post-content {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.8;
   }

--- a/src/pages/moltbook/index.astro
+++ b/src/pages/moltbook/index.astro
@@ -78,7 +78,7 @@ const sorted = entries.sort((a, b) => b.data.date.localeCompare(a.data.date));
   }
 
   .moltbook-item__date {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
   }
@@ -90,18 +90,18 @@ const sorted = entries.sort((a, b) => b.data.date.localeCompare(a.data.date));
   }
 
   .moltbook-item__title {
-    font-size: 1.15rem;
+    font-size: var(--text-lg);
     font-weight: 700;
   }
 
   .moltbook-item__summary {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     line-height: 1.6;
     color: var(--text-secondary);
   }
 
   .moltbook-item__read {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
     margin-top: 0.25rem;

--- a/src/pages/music/index.astro
+++ b/src/pages/music/index.astro
@@ -269,7 +269,7 @@ document.addEventListener('astro:page-load', function () {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
   }
 
@@ -357,7 +357,7 @@ document.addEventListener('astro:page-load', function () {
   }
 
   .song-row__title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 600;
     color: var(--text-primary);
     white-space: nowrap;
@@ -366,7 +366,7 @@ document.addEventListener('astro:page-load', function () {
   }
 
   .song-row__album {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-accent, var(--accent-mid, #ae8dff));
     font-style: italic;
     margin-top: 0.1rem;
@@ -376,7 +376,7 @@ document.addEventListener('astro:page-load', function () {
   }
 
   .song-row__artist {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
   }
 
@@ -384,7 +384,7 @@ document.addEventListener('astro:page-load', function () {
     display: inline-block;
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     background: var(--bg-glass);
     border: 1px solid var(--border-subtle);
     color: var(--text-tertiary);
@@ -395,8 +395,8 @@ document.addEventListener('astro:page-load', function () {
     display: inline-block;
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
-    font-size: 0.65rem;
-    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: var(--text-2xs);
+    font-family: var(--font-mono);
     background: var(--bg-glass);
     border: 1px solid var(--border-subtle);
     color: var(--text-tertiary);
@@ -429,7 +429,7 @@ document.addEventListener('astro:page-load', function () {
   .progress-time {
     display: flex;
     justify-content: space-between;
-    font-size: 0.65rem;
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     margin-top: 0.2rem;
   }
@@ -448,7 +448,7 @@ document.addEventListener('astro:page-load', function () {
   .store-tag {
     padding: 0.1rem 0.4rem;
     border-radius: 4px;
-    font-size: 0.65rem;
+    font-size: var(--text-2xs);
     background: var(--bg-glass);
     border: 1px solid var(--border-subtle);
     color: var(--text-secondary);
@@ -468,7 +468,7 @@ document.addEventListener('astro:page-load', function () {
     gap: 0.3rem;
     padding: 0.25rem 0.55rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     background: var(--bg-glass);
     border: 1px solid var(--border-subtle);
     color: var(--text-secondary);
@@ -497,7 +497,7 @@ document.addEventListener('astro:page-load', function () {
     gap: 0.35rem;
     padding: 0.25rem 0.65rem;
     border-radius: 9999px;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: var(--bg-glass);
     border: 1px solid rgba(255, 255, 255, 0.08);
@@ -518,7 +518,7 @@ document.addEventListener('astro:page-load', function () {
   .song-row__status--delivered { border-color: rgba(34, 197, 94, 0.25); }
 
   .song-row__date {
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
   }
 
@@ -573,15 +573,15 @@ document.addEventListener('astro:page-load', function () {
     }
 
     .song-row__title {
-      font-size: 0.9rem;
+      font-size: var(--text-sm);
     }
 
     .song-row__artist {
-      font-size: 0.8rem;
+      font-size: var(--text-sm);
     }
 
     .store-tag {
-      font-size: 0.6rem;
+      font-size: var(--text-2xs);
     }
   }
 </style>

--- a/src/pages/office/index.astro
+++ b/src/pages/office/index.astro
@@ -76,7 +76,7 @@ import { ViewTransitions } from "astro:transitions";
                 >
                     <div
                         class="ops-office-thumb"
-                        style="display:flex;align-items:center;justify-content:center;background:var(--bg-secondary, #12121a);font-size:3rem;"
+                        style="display:flex;align-items:center;justify-content:center;background:var(--bg-secondary, #12121a);font-size:var(--text-5xl);"
                     >
                         🏢
                     </div>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -127,8 +127,8 @@ const UPDATED = "March 1, 2026";
   }
 
   .legal-meta {
-    font-size: 0.75rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -136,14 +136,14 @@ const UPDATED = "March 1, 2026";
   }
 
   h1 {
-    font-size: 2.5rem;
+    font-size: var(--text-4xl);
     font-weight: 900;
     letter-spacing: -0.03em;
     margin-bottom: 0.75rem;
   }
 
   .legal-entity {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.7;
     margin-bottom: 2.5rem;
@@ -152,7 +152,7 @@ const UPDATED = "March 1, 2026";
   }
 
   h2 {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin-top: 2rem;
     margin-bottom: 0.6rem;
@@ -160,7 +160,7 @@ const UPDATED = "March 1, 2026";
 
   p,
   li {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.75;
   }

--- a/src/pages/store/[slug].astro
+++ b/src/pages/store/[slug].astro
@@ -430,7 +430,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-status {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     color: #22c55e;
     white-space: nowrap;
@@ -438,11 +438,11 @@ const longDescriptionHtml = marked(item.longDescription);
 
   .receipt-sep {
     color: var(--text-tertiary);
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
   }
 
   .receipt-hint {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
   }
@@ -476,7 +476,7 @@ const longDescriptionHtml = marked(item.longDescription);
     background: none;
     border: none;
     padding: 0;
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     color: #22c55e;
     cursor: pointer;
@@ -512,13 +512,13 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-item__name {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-primary);
   }
 
   .receipt-item__price {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
   }
@@ -536,7 +536,7 @@ const longDescriptionHtml = marked(item.longDescription);
     background: #22c55e;
     color: #fff;
     font-weight: 700;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     border-radius: 10px;
     text-decoration: none;
     transition: opacity 0.2s, transform 0.2s;
@@ -549,7 +549,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-note {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin: 0;
     line-height: 1.5;
@@ -560,7 +560,7 @@ const longDescriptionHtml = marked(item.longDescription);
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     margin-bottom: 2.5rem;
   }
@@ -587,7 +587,7 @@ const longDescriptionHtml = marked(item.longDescription);
 
   .product__type-badge {
     display: inline-block;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -608,7 +608,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .product__title {
-    font-size: clamp(1.8rem, 4vw, 2.75rem);
+    font-size: var(--text-4xl);
     font-weight: 900;
     line-height: 1.15;
     margin-bottom: 1rem;
@@ -616,7 +616,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .product__tagline {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     color: var(--text-secondary);
     line-height: 1.6;
     max-width: 580px;
@@ -635,13 +635,13 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .product__about p {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.7;
   }
 
   .product__section-title {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -662,14 +662,14 @@ const longDescriptionHtml = marked(item.longDescription);
     display: flex;
     align-items: flex-start;
     gap: 0.75rem;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
   }
 
   .features-list__check {
     color: var(--text-accent);
     font-weight: 700;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     flex-shrink: 0;
     margin-top: 0.1rem;
   }
@@ -698,13 +698,13 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .price-amount {
-    font-size: 2.5rem;
+    font-size: var(--text-4xl);
     font-weight: 900;
     color: var(--text-primary);
   }
 
   .price-label {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
@@ -715,7 +715,7 @@ const longDescriptionHtml = marked(item.longDescription);
     background: var(--gradient-accent);
     color: #fff;
     font-weight: 700;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     border-radius: 10px;
     text-align: center;
     text-decoration: none;
@@ -741,7 +741,7 @@ const longDescriptionHtml = marked(item.longDescription);
     border: 1px solid var(--border-glass);
     border-radius: 10px;
     text-align: center;
-    font-size: 0.83rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-secondary);
     text-decoration: none;
@@ -766,12 +766,12 @@ const longDescriptionHtml = marked(item.longDescription);
     display: flex;
     align-items: center;
     gap: 0.6rem;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
   .detail-icon {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     flex-shrink: 0;
   }
 
@@ -832,8 +832,8 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .product__model {
-    font-size: 0.75rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
     margin-top: 0.2rem;
     display: block;
@@ -852,7 +852,7 @@ const longDescriptionHtml = marked(item.longDescription);
     align-items: center;
     padding: 0.2rem 0.6rem;
     border-radius: 6px;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: color-mix(in srgb, var(--trait-color) 14%, transparent);
     color: var(--trait-color);
@@ -864,7 +864,7 @@ const longDescriptionHtml = marked(item.longDescription);
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     text-decoration: none;
@@ -896,7 +896,7 @@ const longDescriptionHtml = marked(item.longDescription);
 
   /* Prose styles for markdown long description */
   .prose :global(h2) {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     color: var(--text-primary);
     margin: 1.75rem 0 0.75rem;
@@ -907,7 +907,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .prose :global(p) {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.7;
     margin-bottom: 0.75rem;
@@ -923,7 +923,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .prose :global(li) {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     padding-left: 1.2rem;
     position: relative;
@@ -935,7 +935,7 @@ const longDescriptionHtml = marked(item.longDescription);
     position: absolute;
     left: 0;
     color: var(--text-accent);
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
   }
 
   .prose :global(strong) {
@@ -944,8 +944,8 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .prose :global(code) {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.82rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     background: var(--bg-tertiary);
     padding: 0.1rem 0.4rem;
     border-radius: 4px;
@@ -954,13 +954,13 @@ const longDescriptionHtml = marked(item.longDescription);
 
   .built-by__label {
     display: block;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin-bottom: 0.1rem;
   }
 
   .built-by__name {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-accent);
     text-decoration: none;
@@ -972,7 +972,7 @@ const longDescriptionHtml = marked(item.longDescription);
 
   /* Related */
   .related__title {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -1012,7 +1012,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .related-card__category {
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -1020,19 +1020,19 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .related-card__price {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 800;
     color: var(--text-primary);
   }
 
   .related-card__name {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 700;
     color: var(--text-primary);
   }
 
   .related-card__desc {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.5;
   }
@@ -1066,7 +1066,7 @@ const longDescriptionHtml = marked(item.longDescription);
     }
 
     .price-amount {
-      font-size: 2rem;
+      font-size: var(--text-4xl);
     }
   }
 
@@ -1125,7 +1125,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .store-buy-bar__name {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     white-space: nowrap;
@@ -1134,7 +1134,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .store-buy-bar__price {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
   }
@@ -1144,7 +1144,7 @@ const longDescriptionHtml = marked(item.longDescription);
     align-items: center;
     padding: 0.7rem 2rem;
     border-radius: 10px;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-decoration: none;
     white-space: nowrap;
@@ -1188,7 +1188,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-note {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin: 0;
     line-height: 1.5;
@@ -1201,7 +1201,7 @@ const longDescriptionHtml = marked(item.longDescription);
     gap: 0.35rem;
     padding: 0.3rem 0.65rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: var(--bg-glass);
     border: 1px solid var(--border-glass);
@@ -1235,7 +1235,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-claimed__msg {
-    font-size: 0.83rem;
+    font-size: var(--text-sm);
     color: #b45309;
     margin: 0;
     line-height: 1.5;
@@ -1255,7 +1255,7 @@ const longDescriptionHtml = marked(item.longDescription);
     border: 1px solid var(--border-glass);
     background: var(--bg-secondary);
     color: var(--text-primary);
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     outline: none;
   }
 
@@ -1269,7 +1269,7 @@ const longDescriptionHtml = marked(item.longDescription);
     border: none;
     background: #f59e0b;
     color: #fff;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     cursor: pointer;
     transition: opacity 0.15s;
@@ -1280,7 +1280,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .receipt-claimed__hint {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin: 0;
   }
@@ -1315,20 +1315,20 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .workflow-card__icon {
-    font-size: 1.3rem;
+    font-size: var(--text-xl);
     flex-shrink: 0;
   }
 
   .workflow-card__name {
     display: block;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     font-weight: 700;
     color: var(--text-primary);
   }
 
   .workflow-card__phases {
     display: block;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin-top: 0.1rem;
     text-transform: uppercase;
@@ -1337,7 +1337,7 @@ const longDescriptionHtml = marked(item.longDescription);
 
   .workflow-card__arrow {
     margin-left: auto;
-    font-size: 1rem;
+    font-size: var(--text-base);
     color: var(--text-tertiary);
     transition: transform 0.15s;
   }
@@ -1348,7 +1348,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .workflow-card__desc {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.55;
     margin: 0 0 1rem;
@@ -1371,7 +1371,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .workflow-step__emoji {
-    font-size: 1rem;
+    font-size: var(--text-base);
     flex-shrink: 0;
     line-height: 1.4;
   }
@@ -1383,7 +1383,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .workflow-step__label {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     color: var(--text-primary);
     white-space: nowrap;
@@ -1392,7 +1392,7 @@ const longDescriptionHtml = marked(item.longDescription);
   }
 
   .workflow-step__agent {
-    font-size: 0.68rem;
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     white-space: nowrap;
     overflow: hidden;

--- a/src/pages/store/index.astro
+++ b/src/pages/store/index.astro
@@ -171,7 +171,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
     display: flex;
     align-items: center;
     gap: 0.6rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -198,7 +198,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
 
   .section-count {
     margin-left: auto;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 500;
     color: var(--text-tertiary);
     text-transform: none;
@@ -280,7 +280,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card--subagent .store-card__category {
-    font-size: 0.68rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -290,7 +290,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card--subagent .store-card__name {
-    font-size: 1rem;
+    font-size: var(--text-base);
     margin-bottom: 0;
   }
 
@@ -326,7 +326,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
     position: absolute;
     top: 1.25rem;
     right: 1.25rem;
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -338,7 +338,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card__type {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -354,7 +354,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card__category {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -362,18 +362,18 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card__name {
-    font-size: 1.2rem;
+    font-size: var(--text-xl);
     font-weight: 800;
     margin-bottom: 0.6rem;
     color: var(--text-primary);
   }
 
   .store-card--persona .store-card__name {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
   }
 
   .store-card__desc {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
     margin-bottom: 1.25rem;
@@ -390,7 +390,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card__features li {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     padding-left: 1.2rem;
     position: relative;
@@ -402,7 +402,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
     left: 0;
     color: var(--text-accent);
     font-weight: 700;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
   }
 
   .store-card__footer {
@@ -415,17 +415,17 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
 
   .store-card__price {
-    font-size: 1.4rem;
+    font-size: var(--text-2xl);
     font-weight: 900;
     color: var(--text-primary);
   }
 
   .store-card--persona .store-card__price {
-    font-size: 2rem;
+    font-size: var(--text-4xl);
   }
 
   .store-card__cta {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-accent);
     transition: gap 0.2s;
@@ -445,7 +445,7 @@ const skills = storeItems.filter((i) => i.type === "skill");
   }
   .sold-badge {
     display: inline-block;
-    font-size: 0.65rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     padding: 0.15rem 0.55rem;
     border-radius: 99px;

--- a/src/pages/team/[...slug].astro
+++ b/src/pages/team/[...slug].astro
@@ -166,7 +166,7 @@ const otherAgents = teamMembers
   }
 
   .about-entry__back {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     transition: color 0.2s ease;
   }
@@ -213,19 +213,19 @@ const otherAgents = teamMembers
   }
 
   .about-entry__title {
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    font-size: var(--text-4xl);
     margin-bottom: 0;
   }
 
   .agent-hero__role {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     font-weight: 600;
     color: var(--text-secondary);
   }
 
   .agent-hero__model {
-    font-size: 0.8rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-sm);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
   }
 
@@ -241,7 +241,7 @@ const otherAgents = teamMembers
     align-items: center;
     padding: 0.2rem 0.6rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: color-mix(in srgb, var(--trait-color) 15%, transparent);
     color: var(--trait-color);
@@ -249,7 +249,7 @@ const otherAgents = teamMembers
   }
 
   .about-entry__subtitle {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-tertiary);
     margin-bottom: 2rem;
     max-width: 1200px;
@@ -265,7 +265,7 @@ const otherAgents = teamMembers
   }
 
   .about-entry__content :global(h2) {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     margin-top: 2.5rem;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -277,7 +277,7 @@ const otherAgents = teamMembers
   }
 
   .about-entry__content :global(h3) {
-    font-size: 1.15rem;
+    font-size: var(--text-lg);
     margin-top: 1.5rem;
     margin-bottom: 0.75rem;
   }
@@ -310,7 +310,7 @@ const otherAgents = teamMembers
   }
 
   .about-entry__content :global(code) {
-    font-family: "JetBrains Mono", monospace;
+    font-family: var(--font-mono);
     font-size: 0.85em;
     padding: 0.15rem 0.4rem;
     border-radius: 4px;
@@ -365,7 +365,7 @@ const otherAgents = teamMembers
   }
 
   .other-agents__heading {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     color: var(--text-secondary);
     text-transform: uppercase;
@@ -420,13 +420,13 @@ const otherAgents = teamMembers
   }
 
   .other-agent-card__name {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
   }
 
   .other-agent-card__codename {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
     overflow: hidden;
@@ -434,7 +434,7 @@ const otherAgents = teamMembers
   }
 
   .other-agent-card__arrow {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     transition: transform 0.2s ease;
     flex-shrink: 0;
@@ -494,7 +494,7 @@ const otherAgents = teamMembers
 
   .get-agent-bar__name {
     display: block;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     white-space: nowrap;
@@ -502,7 +502,7 @@ const otherAgents = teamMembers
 
   .get-agent-bar__sub {
     display: block;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
   }
@@ -513,7 +513,7 @@ const otherAgents = teamMembers
     gap: 0.5rem;
     padding: 0.6rem 1.4rem;
     border-radius: 10px;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-decoration: none;
     white-space: nowrap;
@@ -553,7 +553,7 @@ const otherAgents = teamMembers
     }
 
     .get-agent-bar__name {
-      font-size: 0.82rem;
+      font-size: var(--text-sm);
       overflow: hidden;
       text-overflow: ellipsis;
       max-width: 140px;

--- a/src/pages/team/index.astro
+++ b/src/pages/team/index.astro
@@ -175,26 +175,26 @@ const subagents = teamMembers;
   }
 
   .team-card__name {
-    font-size: 1.2rem;
+    font-size: var(--text-xl);
     font-weight: 700;
     margin: 0;
     line-height: 1.2;
   }
 
   .team-card__role {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
 
   .team-card__subrole {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
   }
 
   .team-card__desc {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     line-height: 1.65;
     color: var(--text-secondary);
     flex: 1;
@@ -211,7 +211,7 @@ const subagents = teamMembers;
     align-items: center;
     padding: 0.18rem 0.55rem;
     border-radius: 6px;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: color-mix(in srgb, var(--trait-color) 14%, transparent);
     color: var(--trait-color);
@@ -219,14 +219,14 @@ const subagents = teamMembers;
   }
 
   .team-card__model {
-    font-size: 0.72rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
     margin-top: 0.25rem;
   }
 
   .team-card__view {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     margin-top: auto;
     opacity: 0;
@@ -255,18 +255,18 @@ const subagents = teamMembers;
   }
 
   .office-banner__icon {
-    font-size: 2.5rem;
+    font-size: var(--text-4xl);
     flex-shrink: 0;
   }
 
   .office-banner__content h3 {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin: 0 0 0.2rem;
   }
 
   .office-banner__content p {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     margin: 0;
   }

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -112,8 +112,8 @@ const UPDATED = "March 1, 2026";
   }
 
   .legal-meta {
-    font-size: 0.75rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -121,14 +121,14 @@ const UPDATED = "March 1, 2026";
   }
 
   h1 {
-    font-size: 2.5rem;
+    font-size: var(--text-4xl);
     font-weight: 900;
     letter-spacing: -0.03em;
     margin-bottom: 0.75rem;
   }
 
   .legal-entity {
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.7;
     margin-bottom: 2.5rem;
@@ -137,7 +137,7 @@ const UPDATED = "March 1, 2026";
   }
 
   h2 {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin-top: 2rem;
     margin-bottom: 0.6rem;
@@ -145,7 +145,7 @@ const UPDATED = "March 1, 2026";
 
   p,
   li {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.75;
   }
@@ -164,8 +164,8 @@ const UPDATED = "March 1, 2026";
   }
 
   code {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.8rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     background: var(--bg-glass);
     padding: 0.15rem 0.4rem;
     border-radius: 4px;

--- a/src/pages/til/[...slug].astro
+++ b/src/pages/til/[...slug].astro
@@ -62,7 +62,7 @@ const { Content } = await entry.render();
   }
 
   .til-entry__back {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     transition: color 0.2s ease;
   }
@@ -72,13 +72,13 @@ const { Content } = await entry.render();
   }
 
   .til-entry__date {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
   }
 
   .til-entry__title {
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    font-size: var(--text-4xl);
     margin-bottom: 1rem;
     max-width: 1200px;
     margin-left: auto;
@@ -102,7 +102,7 @@ const { Content } = await entry.render();
   }
 
   .til-entry__content :global(h2) {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     margin-top: 2.5rem;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
@@ -110,7 +110,7 @@ const { Content } = await entry.render();
   }
 
   .til-entry__content :global(h3) {
-    font-size: 1.15rem;
+    font-size: var(--text-lg);
     margin-top: 1.5rem;
     margin-bottom: 0.75rem;
   }
@@ -138,7 +138,7 @@ const { Content } = await entry.render();
   }
 
   .til-entry__content :global(code) {
-    font-family: "JetBrains Mono", monospace;
+    font-family: var(--font-mono);
     font-size: 0.85em;
     padding: 0.15rem 0.4rem;
     border-radius: 4px;

--- a/src/pages/til/index.astro
+++ b/src/pages/til/index.astro
@@ -86,7 +86,7 @@ const sorted = tilEntries.sort((a, b) =>
   }
 
   .til-item__date {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
   }
@@ -98,17 +98,17 @@ const sorted = tilEntries.sort((a, b) =>
   }
 
   .til-item__title {
-    font-size: 1.15rem;
+    font-size: var(--text-lg);
     font-weight: 700;
   }
 
   .til-item__summary {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     line-height: 1.6;
   }
 
   .til-item__read {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--text-accent);
     font-weight: 600;
     margin-top: 0.25rem;

--- a/src/pages/treasury.astro
+++ b/src/pages/treasury.astro
@@ -223,8 +223,8 @@ const OKX =
   }
 
   .tr-chain {
-    font-size: 0.72rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text-tertiary);
@@ -244,7 +244,7 @@ const OKX =
     justify-content: center;
     padding: 0.7rem 1.25rem;
     border-radius: 10px;
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     white-space: nowrap;
     transition: all 0.2s ease;
@@ -290,7 +290,7 @@ const OKX =
   }
 
   .tr-block-title {
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -329,7 +329,7 @@ const OKX =
   }
 
   .tr-addr-label {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-secondary);
   }
@@ -343,8 +343,8 @@ const OKX =
   }
 
   .tr-addr {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.78rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     color: var(--text-primary);
     word-break: break-all;
     line-height: 1.6;
@@ -370,7 +370,7 @@ const OKX =
     gap: 0.3rem;
     padding: 0.3rem 0.7rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: var(--bg-glass);
     border: 1px solid var(--border-glass);
@@ -396,7 +396,7 @@ const OKX =
     align-items: center;
     padding: 0.3rem 0.7rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: color-mix(in srgb, var(--text-accent) 10%, transparent);
     border: 1px solid color-mix(in srgb, var(--text-accent) 20%, transparent);
@@ -441,14 +441,14 @@ const OKX =
   }
 
   .tr-tx-label {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
   }
 
   .tr-tx-hash {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.72rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
   }
 
@@ -468,14 +468,14 @@ const OKX =
 
   .tr-policy-head {
     display: block;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     margin-bottom: 0.4rem;
   }
 
   .tr-policy-item p {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
     margin: 0;
@@ -483,7 +483,7 @@ const OKX =
 
   /* ──── Utility ──── */
   .tr-status-text {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.7;
   }
@@ -497,7 +497,7 @@ const OKX =
   /* ──── Disclaimer ──── */
   .tr-disclaimer {
     margin-top: 1.5rem;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     line-height: 1.65;
     border-left: 2px solid var(--border-subtle);
@@ -507,8 +507,8 @@ const OKX =
   /* ──── Responsive ──── */
   /* ── Live MCap ── */
   .tr-mcap {
-    font-size: 0.75rem;
-    font-family: "JetBrains Mono", monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     color: var(--text-tertiary);
     margin-bottom: 0.4rem;
     min-height: 1.1rem;

--- a/src/pages/workflows.astro
+++ b/src/pages/workflows.astro
@@ -144,7 +144,7 @@ const rest = workflows.filter(w => w.badgeType !== 'featured');
     display: inline-block;
     padding: 0.2rem 0.65rem;
     border-radius: 6px;
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -157,18 +157,18 @@ const rest = workflows.filter(w => w.badgeType !== 'featured');
   }
 
   .wf-card__title {
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
     font-weight: 700;
     margin: 0;
     line-height: 1.3;
   }
 
   .wf-card--live .wf-card__title {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
   }
 
   .wf-card__desc {
-    font-size: 0.88rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.65;
     margin: 0;
@@ -199,22 +199,22 @@ const rest = workflows.filter(w => w.badgeType !== 'featured');
   }
 
   .wf-phase__emoji {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
   }
 
   .wf-phase__label {
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 700;
     color: var(--text-primary);
   }
 
   .wf-phase__agent {
-    font-size: 0.62rem;
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
   }
 
   .wf-card__cta {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-accent);
     margin-top: auto;
@@ -260,7 +260,7 @@ const rest = workflows.filter(w => w.badgeType !== 'featured');
   @media (max-width: 380px) {
     .wf-card__phases {
       grid-template-columns: repeat(3, 1fr);
-      font-size: 0.65rem;
+      font-size: var(--text-2xs);
     }
 
     .wf-phase__agent {

--- a/src/pages/workflows/[slug].astro
+++ b/src/pages/workflows/[slug].astro
@@ -194,7 +194,7 @@ function avatarSrc(step: WorkflowStep): string {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        font-size: 0.82rem;
+        font-size: var(--text-sm);
         color: var(--text-tertiary);
         margin-bottom: 2rem;
     }
@@ -218,7 +218,7 @@ function avatarSrc(step: WorkflowStep): string {
         display: inline-block;
         padding: 0.2rem 0.75rem;
         border-radius: 6px;
-        font-size: 0.72rem;
+        font-size: var(--text-xs);
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.07em;
@@ -230,14 +230,14 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .hero__title {
-        font-size: clamp(1.75rem, 4vw, 2.75rem);
+        font-size: var(--text-4xl);
         font-weight: 800;
         margin-bottom: 0.75rem;
         line-height: 1.15;
     }
 
     .hero__desc {
-        font-size: 1rem;
+        font-size: var(--text-base);
         color: var(--text-secondary);
         max-width: 640px;
         line-height: 1.7;
@@ -299,7 +299,7 @@ function avatarSrc(step: WorkflowStep): string {
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 1.25rem;
+        font-size: var(--text-xl);
         background: var(--bg-glass);
         border: 1px solid var(--border-glass);
         margin-left: -1.25rem;
@@ -329,10 +329,10 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .pipeline__icon-letter {
-        font-size: 0.68rem;
+        font-size: var(--text-2xs);
         font-weight: 900;
         color: var(--text-accent);
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         line-height: 1;
         letter-spacing: -0.04em;
         display: flex;
@@ -368,7 +368,7 @@ function avatarSrc(step: WorkflowStep): string {
     .pipeline__arrow {
         margin-left: 1.5rem;
         padding-left: 1.25rem;
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         color: var(--text-tertiary);
         line-height: 1;
         padding-top: 0.25rem;
@@ -381,9 +381,9 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .pipeline__agent {
-        font-size: 0.75rem;
+        font-size: var(--text-xs);
         color: var(--text-tertiary);
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         margin-bottom: 0.25rem;
     }
 
@@ -392,13 +392,13 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .pipeline__name {
-        font-size: 1.1rem;
+        font-size: var(--text-lg);
         font-weight: 700;
         margin: 0 0 0.4rem;
     }
 
     .pipeline__desc {
-        font-size: 0.875rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.65;
         margin-bottom: 0.75rem;
@@ -414,9 +414,9 @@ function avatarSrc(step: WorkflowStep): string {
         display: inline-flex;
         padding: 0.15rem 0.5rem;
         border-radius: 4px;
-        font-size: 0.72rem;
+        font-size: var(--text-xs);
         font-weight: 600;
-        font-family: "JetBrains Mono", monospace;
+        font-family: var(--font-mono);
         background: var(--bg-glass);
         border: 1px solid var(--border-subtle);
         color: var(--text-secondary);
@@ -429,7 +429,7 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .principles__title {
-        font-size: 1.15rem;
+        font-size: var(--text-lg);
         font-weight: 700;
         margin-bottom: 1.5rem;
     }
@@ -447,19 +447,19 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .principle__icon {
-        font-size: 1.3rem;
+        font-size: var(--text-xl);
         flex-shrink: 0;
         margin-top: 0.1rem;
     }
 
     .principle strong {
         display: block;
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         margin-bottom: 0.25rem;
     }
 
     .principle p {
-        font-size: 0.8rem;
+        font-size: var(--text-sm);
         color: var(--text-secondary);
         line-height: 1.5;
         margin: 0;
@@ -475,7 +475,7 @@ function avatarSrc(step: WorkflowStep): string {
     }
 
     .cta__text {
-        font-size: 1rem;
+        font-size: var(--text-base);
         color: var(--text-secondary);
         margin: 0 0 1.25rem;
     }
@@ -487,7 +487,7 @@ function avatarSrc(step: WorkflowStep): string {
         background: var(--text-accent);
         color: #fff;
         font-weight: 700;
-        font-size: 0.9rem;
+        font-size: var(--text-sm);
         text-decoration: none;
         transition: opacity 0.15s;
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,8 +21,9 @@ html {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.6;
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.65;
   overflow-x: hidden;
 }
 
@@ -43,6 +44,42 @@ a {
 ul,
 ol {
   list-style: none;
+}
+
+/* ---------- Design Tokens: Type Scale (shared across themes) ---------- */
+:root {
+  /* Font families — single source of truth. All components consume these
+     via var(--font-sans) / var(--font-mono); never hardcode the stacks. */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Sizes — Tailwind-style modular scale, with two extra small stops for
+     micro-UI (chips, badges) and three fluid stops for display headings. */
+  --text-2xs: 0.6875rem;   /* 11px */
+  --text-xs:  0.75rem;     /* 12px */
+  --text-sm:  0.875rem;    /* 14px */
+  --text-base: 1rem;       /* 16px — body floor */
+  --text-lg:  1.125rem;    /* 18px */
+  --text-xl:  1.25rem;     /* 20px */
+  --text-2xl: 1.5rem;      /* 24px */
+  --text-3xl: clamp(1.5rem, 2.5vw, 1.875rem);   /* h3 */
+  --text-4xl: clamp(1.875rem, 4vw, 2.5rem);     /* h2 */
+  --text-5xl: clamp(2.5rem, 6vw, 3.75rem);      /* h1 */
+  --text-display: clamp(3rem, 8vw, 5.5rem);     /* hero display */
+
+  /* Line-heights — paired with sizes by convention, not enforced here */
+  --leading-tight: 1.15;
+  --leading-snug: 1.35;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.65;
+
+  /* Letter-spacing — negative for large display, positive for small all-caps labels */
+  --tracking-tighter: -0.025em;
+  --tracking-tight: -0.015em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.04em;
+  --tracking-wider: 0.06em;
+  --tracking-widest: 0.08em;
 }
 
 /* ---------- Design Tokens: Dark Theme (Default) ---------- */
@@ -163,30 +200,66 @@ h4,
 h5,
 h6 {
   font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
 }
 
 h1 {
-  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-size: var(--text-5xl);
+  letter-spacing: var(--tracking-tighter);
 }
 
 h2 {
-  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-size: var(--text-4xl);
+  letter-spacing: -0.02em;
 }
 
 h3 {
-  font-size: clamp(1.2rem, 2.5vw, 1.75rem);
+  font-size: var(--text-3xl);
+}
+
+h4 {
+  font-size: var(--text-2xl);
+  letter-spacing: -0.01em;
+}
+
+h5 {
+  font-size: var(--text-xl);
+  letter-spacing: -0.005em;
+}
+
+h6 {
+  font-size: var(--text-lg);
+  letter-spacing: 0;
 }
 
 p {
-  font-size: clamp(0.95rem, 1.2vw, 1.1rem);
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
   color: var(--text-secondary);
+}
+
+/* Utility text classes — use these instead of arbitrary font-size values */
+.text-2xs { font-size: var(--text-2xs); }
+.text-xs  { font-size: var(--text-xs); }
+.text-sm  { font-size: var(--text-sm); }
+.text-base { font-size: var(--text-base); }
+.text-lg  { font-size: var(--text-lg); }
+.text-xl  { font-size: var(--text-xl); }
+.text-2xl { font-size: var(--text-2xl); }
+
+/* Label style: small, uppercase, tracked — for chips/captions */
+.text-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  line-height: var(--leading-snug);
 }
 
 code,
 .mono {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
 }
 
 /* ---------- Glass Card (Peaq-inspired) ---------- */
@@ -240,8 +313,8 @@ code,
 }
 
 .page-header__title {
-  font-family: 'Inter', sans-serif;
-  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-family: var(--font-sans);
+  font-size: var(--text-display);
   font-weight: 800;
   letter-spacing: -0.03em;
   line-height: 1.1;
@@ -250,8 +323,8 @@ code,
 }
 
 .page-header__subtitle {
-  font-family: 'Inter', sans-serif;
-  font-size: clamp(0.95rem, 1.2vw, 1.1rem);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
   color: var(--text-secondary);
   line-height: 1.6;
   max-width: 640px;
@@ -383,7 +456,7 @@ code,
   gap: 0.5rem;
   padding: 0.3rem 0.85rem;
   border-radius: 9999px;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0.02em;
   background: rgba(74, 222, 128, 0.08);
@@ -463,7 +536,7 @@ code,
   padding: 0.75rem 1.5rem;
   border-radius: 12px;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: var(--text-base);
   cursor: pointer;
   border: none;
   transition: all 0.3s ease;
@@ -498,8 +571,9 @@ code,
   align-items: center;
   padding: 0.2rem 0.6rem;
   border-radius: 6px;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 500;
+  letter-spacing: var(--tracking-wide);
   background: var(--bg-glass);
   color: var(--text-secondary);
   border: 1px solid var(--border-subtle);

--- a/src/styles/office-dashboard.css
+++ b/src/styles/office-dashboard.css
@@ -17,8 +17,8 @@
 }
 
 .ops-hero__chain {
-    font-size: 0.72rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text-tertiary);
@@ -29,7 +29,7 @@
 }
 
 .ops-hero__title {
-    font-size: clamp(2.5rem, 6vw, 3.5rem);
+    font-size: var(--text-5xl);
     font-weight: 900;
     line-height: 1.05;
     letter-spacing: -0.03em;
@@ -41,7 +41,7 @@
 }
 
 .ops-hero__desc {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.6;
     max-width: 480px;
@@ -66,8 +66,8 @@
 
 /* ── Section Titles ─────────────────────────────────────────────────── */
 .ops-section-title {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    font-size: 0.7rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -134,8 +134,8 @@
 
 .ops-office-card__label {
     color: #fff;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.85rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 500;
 }
 
@@ -206,16 +206,16 @@
 }
 
 .ops-info-card__value {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    font-size: 1.5rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xl);
     font-weight: 800;
     color: var(--text-primary);
     line-height: 1;
 }
 
 .ops-info-card__label {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.68rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -243,14 +243,14 @@
 }
 
 .ops-roster__name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.85rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 700;
 }
 
 .ops-roster__role {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.8rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-secondary);
 }
 
@@ -258,9 +258,9 @@
     display: inline-block;
     padding: 0.2rem 0.6rem;
     border-radius: 6px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-sans);
 }
 
 .ops-roster__status--working {
@@ -276,8 +276,8 @@
 }
 
 .ops-roster__task {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.8rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-secondary);
 }
 
@@ -306,8 +306,8 @@
     border: 1px solid var(--border-glass);
     background: var(--bg-glass);
     color: var(--text-primary);
-    font-family: 'Inter', sans-serif;
-    font-size: 0.8rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     cursor: pointer;
     outline: none;
     transition: border-color 0.15s;
@@ -334,8 +334,8 @@
 .ops-table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.85rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
 }
 
 .ops-table thead {
@@ -346,7 +346,7 @@
     text-align: left;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--text-secondary);
@@ -378,14 +378,14 @@
 }
 
 .ops-table__board {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
     color: var(--text-secondary);
     white-space: nowrap;
 }
 
 .ops-table__time {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.72rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
 }
@@ -412,8 +412,8 @@
     display: inline-block;
     padding: 0.2rem 0.6rem;
     border-radius: 6px;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     font-weight: 600;
     white-space: nowrap;
 }
@@ -448,8 +448,8 @@
     display: inline-block;
     padding: 0.15rem 0.45rem;
     border-radius: 6px;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.68rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xs);
     font-weight: 500;
     background: color-mix(in srgb, var(--label-color, #7c3aed) 12%, transparent);
     color: var(--label-color, #a29bfe);
@@ -458,14 +458,14 @@
 }
 
 .ops-label--sm {
-    font-size: 0.65rem;
+    font-size: var(--text-2xs);
     padding: 0.1rem 0.35rem;
 }
 
 /* Lock icon */
 .ops-lock {
     margin-right: 0.35rem;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
 }
 
 /* ── Backlog Queue ──────────────────────────────────────────────────── */
@@ -498,8 +498,8 @@
 
 .ops-backlog-item__title {
     flex: 1;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.85rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -507,8 +507,8 @@
 }
 
 .ops-backlog-item__meta {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     white-space: nowrap;
 }
@@ -523,7 +523,7 @@
     padding: 1.5rem;
     color: var(--text-tertiary);
     font-style: italic;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
 }
 
 /* ── Toast ───────────────────────────────────────────────────────────── */
@@ -537,8 +537,8 @@
     background: var(--glass-bg);
     border: 1px solid var(--glass-border);
     color: var(--text-primary);
-    font-family: 'Inter', sans-serif;
-    font-size: 0.85rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     opacity: 0;

--- a/src/styles/office-upgrades.css
+++ b/src/styles/office-upgrades.css
@@ -19,8 +19,8 @@
     display: inline-block;
     padding: 0.3rem 0.8rem;
     border-radius: 999px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -31,8 +31,8 @@
 }
 
 .upgrades-hero__title {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    font-size: clamp(2.5rem, 6vw, 4rem);
+    font-family: var(--font-sans);
+    font-size: var(--text-display);
     font-weight: 800;
     line-height: 1.1;
     letter-spacing: -0.03em;
@@ -44,8 +44,8 @@
 }
 
 .upgrades-hero__sub {
-    font-family: 'Inter', sans-serif;
-    font-size: 1rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
     color: var(--text-secondary);
     margin: 0 0 1.5rem;
     max-width: 560px;
@@ -64,15 +64,15 @@
 }
 
 .upgrades-hero__stat-value {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 1.6rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xl);
     font-weight: 700;
     color: var(--accent);
 }
 
 .upgrades-hero__stat-label {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -129,8 +129,8 @@
 }
 
 .building-card__render-label {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.65rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -138,7 +138,7 @@
 }
 
 .building-card__arrow {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     color: var(--accent);
     align-self: center;
 }
@@ -150,16 +150,16 @@
 }
 
 .building-card__title {
-    font-family: 'Inter', sans-serif;
-    font-size: 1.5rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xl);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0;
 }
 
 .building-card__desc {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.9rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: 1.5;
     margin: 0;
@@ -178,15 +178,15 @@
 }
 
 .building-card__progress-amount {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 1.2rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xl);
     font-weight: 700;
     color: var(--accent);
 }
 
 .building-card__progress-goal {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.8rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
 }
 
@@ -214,8 +214,8 @@
 .building-card__progress-meta {
     display: flex;
     justify-content: space-between;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
 }
 
@@ -233,8 +233,8 @@
     border: 1px solid var(--border-subtle);
     background: var(--bg-surface);
     color: var(--text-primary);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.85rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
 }
 
 .building-card__input:focus {
@@ -256,16 +256,16 @@
 }
 
 .upgrades-section__title {
-    font-family: 'Inter', sans-serif;
-    font-size: 1.15rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-lg);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0;
 }
 
 .upgrades-section__count {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
 }
 
@@ -307,8 +307,8 @@
 }
 
 .agent-upgrade-card__name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.95rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0 0 0.4rem;
@@ -334,8 +334,8 @@
 }
 
 .agent-upgrade-card__level-type {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -362,8 +362,8 @@
 }
 
 .agent-upgrade-card__level-name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     color: var(--text-secondary);
 }
 
@@ -406,16 +406,16 @@
 }
 
 .furniture-card__name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.92rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0 0 0.3rem;
 }
 
 .furniture-card__desc {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.78rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     color: var(--text-secondary);
     margin: 0 0 0.6rem;
     line-height: 1.4;
@@ -448,8 +448,8 @@
 }
 
 .furniture-card__price {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.78rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     color: var(--accent);
     font-weight: 600;
 }
@@ -462,8 +462,8 @@
     padding: 0.5rem 1rem;
     border-radius: 8px;
     border: none;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.78rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -494,7 +494,7 @@
 
 .btn-upgrade--small {
     padding: 0.35rem 0.7rem;
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
 }
 
 .btn-upgrade--maxed {
@@ -520,8 +520,8 @@
     background: var(--bg-card);
     border: 1px solid rgba(0, 206, 201, 0.3);
     color: #00cec9;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.9rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 600;
     z-index: 9999;
     box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
@@ -556,19 +556,19 @@
 }
 
 .thankyou-card__icon {
-    font-size: 1.5rem;
+    font-size: var(--text-2xl);
     flex-shrink: 0;
 }
 
 .thankyou-card__title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 800;
     color: #22c55e;
     margin: 0;
 }
 
 .thankyou-card__subtitle {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     margin: 0;
 }
@@ -595,7 +595,7 @@
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
 }
 
 .thankyou-card__label {
@@ -609,7 +609,7 @@
 }
 
 .thankyou-card__value--amount {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 800;
     color: #22c55e;
 }
@@ -627,7 +627,7 @@
     border-radius: 8px;
     background: #22c55e;
     color: #fff;
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     text-decoration: none;
     transition: opacity 0.15s, transform 0.15s;
@@ -647,7 +647,7 @@
     border: 1px solid var(--border-subtle);
     background: transparent;
     color: var(--text-secondary);
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     font-weight: 600;
     text-decoration: none;
     transition: border-color 0.15s;
@@ -722,7 +722,7 @@
     border: none;
     color: var(--text-tertiary);
     cursor: pointer;
-    font-size: 1.2rem;
+    font-size: var(--text-xl);
     padding: 0.3rem;
     line-height: 1;
 }
@@ -732,8 +732,8 @@
 }
 
 .upgrade-modal__title {
-    font-family: 'Inter', sans-serif;
-    font-size: 1.2rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xl);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0 0 1rem;
@@ -749,24 +749,24 @@
 }
 
 .upgrade-modal__level-name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.95rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
     font-weight: 600;
     color: var(--accent);
     margin: 0 0 0.3rem;
 }
 
 .upgrade-modal__level-desc {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.82rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     margin: 0 0 1rem;
     line-height: 1.4;
 }
 
 .upgrade-modal__price {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 1.4rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xl);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0 0 1rem;
@@ -782,8 +782,8 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.82rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     text-decoration: none;
     margin-bottom: 1.5rem;
@@ -822,7 +822,7 @@
     }
 
     .upgrades-hero__title {
-        font-size: 1.8rem;
+        font-size: var(--text-3xl);
     }
 }
 
@@ -867,8 +867,8 @@
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     background: rgba(0, 0, 0, 0.5);
     padding: 0.3rem 0.8rem;
@@ -905,8 +905,8 @@
     display: inline-block;
     padding: 0.25rem 0.7rem;
     border-radius: 999px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.65rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -917,8 +917,8 @@
 }
 
 .upgrade-detail__title {
-    font-family: 'Inter', sans-serif;
-    font-size: 2rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-4xl);
     font-weight: 800;
     color: var(--text-primary);
     margin: 0;
@@ -926,8 +926,8 @@
 }
 
 .upgrade-detail__desc {
-    font-family: 'Inter', sans-serif;
-    font-size: 1rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
     color: var(--text-secondary);
     line-height: 1.6;
     margin: 0;
@@ -982,8 +982,8 @@
     width: 32px;
     height: 32px;
     border-radius: 8px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.65rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     font-weight: 700;
     background: rgba(255, 255, 255, 0.06);
     color: var(--text-tertiary);
@@ -998,8 +998,8 @@
 }
 
 .upgrade-detail__level-name {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.92rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     margin: 0;
@@ -1007,15 +1007,15 @@
 }
 
 .upgrade-detail__level-price {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.85rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--accent);
 }
 
 .upgrade-detail__level-desc {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.78rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     color: var(--text-secondary);
     margin: 0.4rem 0 0;
     padding-left: 38px;
@@ -1043,8 +1043,8 @@
     border: none;
     background: var(--accent, #6c5ce7);
     color: #fff;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.8rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
     font-weight: 700;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -1074,14 +1074,14 @@
 
 .btn-upgrade--large {
     padding: 0.8rem 2rem;
-    font-size: 1rem;
+    font-size: var(--text-base);
     border-radius: 10px;
 }
 
 /* ── Contribution Buttons ───────────────────────────────────────── */
 .promote-label {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.75rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     font-weight: 700;
     color: var(--text-secondary);
     margin: 0 0 0.6rem 0;
@@ -1097,8 +1097,8 @@
 }
 
 .promote-btn {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.9rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     font-weight: 700;
     padding: 0.7rem 1.4rem;
     border-radius: 10px;
@@ -1138,7 +1138,7 @@
 }
 
 .promote-btn--bar {
-    font-size: 0.82rem;
+    font-size: var(--text-sm);
     padding: 0.55rem 0;
     border-radius: 8px;
 }
@@ -1151,7 +1151,7 @@
     .promote-btn--bar {
         flex: 1 1 calc(33.33% - 0.3rem);
         min-width: 0;
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
         padding: 0.65rem 0;
     }
 
@@ -1179,15 +1179,15 @@
 }
 
 .progress-bar__raised {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.78rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     font-weight: 700;
     color: var(--text-accent);
 }
 
 .progress-bar__goal {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.68rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xs);
     font-weight: 500;
     color: var(--text-tertiary);
 }
@@ -1214,8 +1214,8 @@
 
 .progress-bar__text {
     display: block;
-    font-family: 'Inter', sans-serif;
-    font-size: 0.62rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-2xs);
     color: var(--text-tertiary);
     margin-top: 0.25rem;
 }
@@ -1235,11 +1235,11 @@
 }
 
 .progress-bar--large .progress-bar__raised {
-    font-size: 1rem;
+    font-size: var(--text-base);
 }
 
 .progress-bar--large .progress-bar__goal {
-    font-size: 0.78rem;
+    font-size: var(--text-xs);
 }
 
 .progress-bar--large .progress-bar__track {
@@ -1252,13 +1252,13 @@
 }
 
 .progress-bar--large .progress-bar__text {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     margin-top: 0.4rem;
 }
 
 .upgrade-detail__disclaimer {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     margin: 0;
     line-height: 1.4;
@@ -1269,8 +1269,8 @@
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.6rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
     font-weight: 700;
     letter-spacing: 0.05em;
     padding: 0.2rem 0.5rem;
@@ -1288,7 +1288,7 @@
     }
 
     .upgrade-detail__title {
-        font-size: 1.5rem;
+        font-size: var(--text-2xl);
     }
 
     .upgrade-detail__level-thumb {
@@ -1329,14 +1329,14 @@
 }
 
 .upgrade-bar__name {
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--text-primary);
     white-space: nowrap;
 }
 
 .upgrade-bar__sub {
-    font-size: 0.72rem;
+    font-size: var(--text-xs);
     color: var(--text-tertiary);
     white-space: nowrap;
 }
@@ -1368,8 +1368,8 @@
 }
 
 .upgrade-bar__cta {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
     font-weight: 700;
     color: var(--text-secondary);
     text-transform: uppercase;
@@ -1383,7 +1383,7 @@
     gap: 0.5rem;
     padding: 0.6rem 1.4rem;
     border-radius: 10px;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     font-weight: 700;
     white-space: nowrap;
     flex-shrink: 0;

--- a/src/styles/office.css
+++ b/src/styles/office.css
@@ -53,7 +53,7 @@
     align-items: center;
     gap: 0.5rem;
     font-weight: 700;
-    font-size: 0.95rem;
+    font-size: var(--text-base);
     color: var(--text-primary);
     text-decoration: none;
     padding: 0.35rem 0.7rem;
@@ -72,7 +72,7 @@
 }
 
 .office-topbar__title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 700;
     color: var(--text-primary);
     letter-spacing: -0.01em;
@@ -84,7 +84,7 @@
     gap: 0.4rem;
     padding: 0.2rem 0.7rem;
     border-radius: 9999px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     background: rgba(74, 222, 128, 0.08);
     color: var(--status-active);
@@ -163,7 +163,7 @@
 .office-toolbar__btn--toggle {
     min-width: 44px;
     font-weight: 700;
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     letter-spacing: 0.03em;
 }
 
@@ -212,7 +212,7 @@
     border-radius: 8px;
     background: transparent;
     color: var(--text-tertiary);
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -241,14 +241,14 @@
 }
 
 .office-agent-panel__name {
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
     font-weight: 700;
     margin-bottom: 0.2rem;
     color: var(--text-primary);
 }
 
 .office-agent-panel__role {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
     font-weight: 500;
     display: block;
@@ -261,7 +261,7 @@
     gap: 0.4rem;
     padding: 0.25rem 0.65rem;
     border-radius: 9999px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     margin-bottom: 0.75rem;
 }
@@ -294,7 +294,7 @@
     display: inline-flex;
     padding: 0.15rem 0.5rem;
     border-radius: 6px;
-    font-size: 0.7rem;
+    font-size: var(--text-2xs);
     font-weight: 600;
 }
 
@@ -305,7 +305,7 @@
     }
 
     .office-topbar__title {
-        font-size: 0.85rem;
+        font-size: var(--text-sm);
     }
 
     .office-topbar__back span {


### PR DESCRIPTION
## Summary

Sitewide typography refresh in one PR. Two design-system tokens (`--font-sans`, `--font-mono`) plus an 11-stop type scale now drive every text rule across the entire codebase. Roughly **400 font-size swaps** + **92 font-family swaps** across **41 files**.

### What changed

**`src/styles/global.css` — new tokens**

```css
--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
--font-mono: 'JetBrains Mono', 'Fira Code', monospace;

--text-2xs   0.6875rem
--text-xs    0.75rem
--text-sm    0.875rem
--text-base  1rem            ← body floor (was 0.95rem)
--text-lg    1.125rem
--text-xl    1.25rem
--text-2xl   1.5rem
--text-3xl   clamp(1.5rem, 2.5vw, 1.875rem)
--text-4xl   clamp(1.875rem, 4vw, 2.5rem)
--text-5xl   clamp(2.5rem, 6vw, 3.75rem)
--text-display clamp(3rem, 8vw, 5.5rem)

--leading-tight 1.15 / --leading-snug 1.35 / --leading-normal 1.5 / --leading-relaxed 1.65
--tracking-tighter -0.025em / --tracking-tight -0.015em / --tracking-normal 0
--tracking-wide 0.04em / --tracking-wider 0.06em / --tracking-widest 0.08em
```

Body baseline lifted to `1rem` (mobile body is now 16px instead of ~15.2px). Heading rules consume the scale tokens. New utility classes: `.text-xs` through `.text-2xl` plus `.text-label`.

**Component + page sweep**

Strict nearest-stop rubric applied to every `font-size` in `src/components/*.astro`, `src/pages/**/*.astro`, and `src/styles/*.css`. Em values (e.g. `font-size: 0.85em` on code blocks) preserved — those are relative-to-parent and intentional.

**Body-clamp false positives caught by post-sweep review**

A handful of `clamp()` declarations were body-sized but the rubric initially mapped them to `--text-3xl` (heading territory). Hand-tuned downstream:

| Selector | Final size |
|---|---|
| `.hero__subtitle` | `--text-lg` |
| `.ph__subtitle` (PageHeader) | `--text-base` |
| `.page-header__subtitle` (global) | `--text-base` |
| `.operator-title` (contact) | `--text-xl` |
| `.blog-card__title` | `--text-xl` |
| `.blog-post__content h3` | `--text-xl` |

**Font-family unification**

92 explicit `font-family: "Inter", ...` and `font-family: "JetBrains Mono", ...` declarations across 22 files (including the `src/styles/office-dashboard.css` / `office-upgrades.css` / `office.css` files my agents didn't initially cover) replaced with `var(--font-sans)` / `var(--font-mono)`. Only three `font-family: inherit` declarations remain — those are on `<button>` elements that intentionally inherit body styling.

**Micro-fixes**

- Footer CA (`0xacb45…`) bumped from `--text-xs` to `--text-sm` — easier to read when copying.
- Hero live-strip labels bumped from `--text-2xs` to `--text-xs` with `--tracking-wider`.
- Global `.chip` gained `--tracking-wide` so tag chips no longer look cramped.

### Verification

```
$ grep -rnE 'font-size:\s*[0-9]+(\.[0-9]+)?rem|font-size:\s*clamp\(' src/  → empty
$ grep -rnE "font-family:\s*['\"](Inter|JetBrains)" src/ | grep -v styles/global.css  → empty
```

No raw rem/clamp font-size values and no literal font stacks outside the canonical token definitions.

## Test plan

- [ ] Eyeball the home page — body text feels slightly more substantial (16px vs 15.2px), hero subtitle and live-strip readable, CTAs unchanged
- [ ] Blog index + a sample blog post — card titles ~20px, body 16px, h3s look smaller than h2s (hierarchy intact)
- [ ] Dashboard — numbers and labels render at the same visual weight as before
- [ ] Footer — CA address is now noticeably more readable
- [ ] Toggle dark/light — typography unaffected (tokens are theme-agnostic)
- [ ] Mobile (≤640px) — clamp() display sizes still scale fluidly

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_