### PR TITLE
feat(feed): pull live X data for @aleisterai

### DIFF
--- a/src/components/Feed.astro
+++ b/src/components/Feed.astro
@@ -61,21 +61,22 @@ const tweets = [
           src="/images/aleister-avatar.png"
           alt="Aleister Avatar"
           class="feed__avatar"
+          id="feed-avatar"
           onerror="this.src='https://github.com/aleisterai.png'"
         />
         <div class="feed__profile-info">
           <a href="https://twitter.com/aleisterai" target="_blank" rel="noopener noreferrer" class="feed__profile-name">
             @{xProfile.handle}
           </a>
-          <p class="feed__profile-desc">{xProfile.description}</p>
+          <p class="feed__profile-desc" id="feed-desc">{xProfile.description}</p>
         </div>
         <div class="feed__profile-stats">
           <div class="feed__stat">
-            <span class="feed__stat-val">{xProfile.followers}</span>
+            <span class="feed__stat-val" id="feed-followers">{xProfile.followers}</span>
             <span class="feed__stat-label">FOLLOWERS</span>
           </div>
           <div class="feed__stat">
-            <span class="feed__stat-val">{xProfile.following}</span>
+            <span class="feed__stat-val" id="feed-following">{xProfile.following}</span>
             <span class="feed__stat-label">FOLLOWING</span>
           </div>
         </div>
@@ -93,7 +94,7 @@ const tweets = [
       </aside>
 
       <!-- Twitter Posts -->
-      <div class="feed__posts">
+      <div class="feed__posts" id="feed-posts">
         {tweets.map((tweet) => (
           <a href="https://x.com/aleisterai" target="_blank" rel="noopener noreferrer" class="glass-card feed__post">
             {tweet.isPinned && (
@@ -350,9 +351,173 @@ const tweets = [
     .feed__layout {
       grid-template-columns: 1fr;
     }
-    
+
     .feed__sidebar {
       position: static;
     }
   }
 </style>
+
+<script is:inline>
+  (function () {
+    const HANDLE = "aleisterai";
+    const AVATAR = "/images/aleister-avatar.png";
+
+    function esc(s) {
+      return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+        return {
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        }[c];
+      });
+    }
+
+    function fmtCount(n) {
+      n = Number(n) || 0;
+      if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+      if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
+      return String(n);
+    }
+
+    function timeAgo(iso) {
+      if (!iso) return "";
+      const then = new Date(iso).getTime();
+      if (!isFinite(then)) return esc(iso);
+      const secs = Math.max(0, (Date.now() - then) / 1000);
+      if (secs < 60) return Math.floor(secs) + "s";
+      if (secs < 3600) return Math.floor(secs / 60) + "m";
+      if (secs < 86400) return Math.floor(secs / 3600) + "h";
+      const d = new Date(then);
+      const sameYear = d.getFullYear() === new Date().getFullYear();
+      const opts = sameYear
+        ? { month: "short", day: "numeric" }
+        : { month: "short", day: "numeric", year: "numeric" };
+      return d.toLocaleDateString("en-US", opts);
+    }
+
+    // Shared SVG snippets (trusted, static)
+    const SVG = {
+      pin: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M7 4.5C7 3.12 8.12 2 9.5 2h5C15.88 2 17 3.12 17 4.5v5.26L20.12 16H13v5l-1 2-1-2v-5H3.88L7 9.76V4.5z"/></svg>',
+      verified:
+        '<svg viewBox="0 0 24 24" width="16" height="16" fill="#1d9bf0" style="margin-left:2px"><path d="M22.5 12.5c0-1.58-.875-2.95-2.148-3.6.154-.435.238-.905.238-1.4 0-2.21-1.71-3.998-3.918-3.998-.47 0-.92.084-1.336.25C14.818 2.415 13.51 1.5 12 1.5s-2.816.917-3.337 2.25c-.416-.165-.866-.25-1.336-.25-2.21 0-3.918 1.79-3.918 4 0 .495.084.965.238 1.4-1.273.65-2.148 2.02-2.148 3.6 0 1.46.74 2.766 1.873 3.46-.01.155-.015.31-.015.466 0 3.328 3.877 6.024 8.643 6.024 4.764 0 8.642-2.696 8.642-6.024 0-.156-.005-.31-.015-.466 1.134-.694 1.873-2 1.873-3.46zM10.15 17l-3.35-3.35 1.41-1.411 1.94 1.94 5.43-5.43 1.41 1.41L10.15 17z"/></svg>',
+      logo: '<svg viewBox="0 0 24 24" width="16" height="16" fill="var(--text-tertiary)"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+      reply:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>',
+      retweet:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 1l4 4-4 4"></path><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><path d="M7 23l-4-4 4-4"></path><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>',
+      like: '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>',
+      views:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M8.75 21V3h2v18h-2zM18 21V8.5h2V21h-2zM4 21l.004-10h2L6 21H4zm9.248 0v-7h2v7h-2z"/></svg>',
+    };
+
+    function renderTweet(t, name) {
+      const url =
+        "https://x.com/" + HANDLE + (t.id ? "/status/" + encodeURIComponent(t.id) : "");
+      const pinned = t.isPinned
+        ? '<div class="feed__post-pinned">' + SVG.pin + "<span>Pinned</span></div>"
+        : "";
+      return (
+        '<a href="' +
+        esc(url) +
+        '" target="_blank" rel="noopener noreferrer" class="glass-card feed__post">' +
+        pinned +
+        '<div class="feed__post-header">' +
+        '<img src="' +
+        AVATAR +
+        '" alt="Aleister Avatar" class="feed__post-avatar" onerror="this.src=\'https://github.com/aleisterai.png\'" />' +
+        '<div class="feed__post-author">' +
+        '<span class="feed__post-name">' +
+        esc(name) +
+        "</span>" +
+        SVG.verified +
+        '<span class="feed__post-handle">@' +
+        esc(HANDLE) +
+        "</span>" +
+        '<span class="feed__post-dot">·</span>' +
+        '<span class="feed__post-time">' +
+        esc(timeAgo(t.created_at)) +
+        "</span>" +
+        "</div>" +
+        '<div class="feed__post-logo">' +
+        SVG.logo +
+        "</div>" +
+        "</div>" +
+        '<p class="feed__post-body">' +
+        esc(t.content) +
+        "</p>" +
+        '<div class="feed__post-actions">' +
+        '<div class="feed__action">' +
+        SVG.reply +
+        "<span>" +
+        fmtCount(t.replies) +
+        "</span></div>" +
+        '<div class="feed__action">' +
+        SVG.retweet +
+        "<span>" +
+        fmtCount(t.retweets) +
+        "</span></div>" +
+        '<div class="feed__action feed__action--like">' +
+        SVG.like +
+        "<span>" +
+        fmtCount(t.likes) +
+        "</span></div>" +
+        '<div class="feed__action">' +
+        SVG.views +
+        "<span>" +
+        fmtCount(t.views) +
+        "</span></div>" +
+        "</div>" +
+        "</a>"
+      );
+    }
+
+    async function loadFeed() {
+      const postsEl = document.getElementById("feed-posts");
+      if (!postsEl) return;
+      try {
+        const res = await fetch("/api/x-feed.json");
+        const data = await res.json();
+        if (!data || data.success === false || !data.tweets || !data.tweets.length) {
+          return; // keep server-rendered fallback
+        }
+
+        // Profile sidebar
+        if (data.profile) {
+          const p = data.profile;
+          const descEl = document.getElementById("feed-desc");
+          const folEl = document.getElementById("feed-followers");
+          const fingEl = document.getElementById("feed-following");
+          const avEl = document.getElementById("feed-avatar");
+          if (descEl && p.description) descEl.textContent = p.description;
+          if (folEl) folEl.textContent = fmtCount(p.followers);
+          if (fingEl) fingEl.textContent = fmtCount(p.following);
+          if (avEl && p.avatar) {
+            avEl.src = p.avatar;
+            avEl.removeAttribute("onerror");
+          }
+          const name = p.name || "Aleister";
+          postsEl.innerHTML = data.tweets
+            .map(function (t) {
+              return renderTweet(t, name);
+            })
+            .join("");
+        } else {
+          postsEl.innerHTML = data.tweets
+            .map(function (t) {
+              return renderTweet(t, "Aleister");
+            })
+            .join("");
+        }
+      } catch (_) {
+        // network error — keep fallback
+      }
+    }
+
+    document.addEventListener("astro:page-load", function () {
+      if (document.getElementById("feed-posts")) loadFeed();
+    });
+  })();
+</script>

--- a/src/pages/api/x-feed.json.ts
+++ b/src/pages/api/x-feed.json.ts
@@ -1,0 +1,217 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+
+// ── Live X / Twitter feed for @aleisterai ─────────────────────────────
+// Pulls profile + recent tweets. Source priority:
+//   1. Official X API v2  — if X_BEARER_TOKEN is set (cheapest, canonical)
+//   2. Apify tweet-scraper — uses the existing APIFY_TOKEN otherwise
+// Server-cached so we don't hammer either source on every page load.
+
+const HANDLE = 'aleisterai';
+const APIFY_TOKEN = import.meta.env.APIFY_TOKEN || process.env.APIFY_TOKEN || '';
+const X_BEARER =
+    import.meta.env.X_BEARER_TOKEN || process.env.X_BEARER_TOKEN || '';
+
+const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+let cache: { data: FeedPayload; timestamp: number } | null = null;
+
+interface FeedTweet {
+    id: string;
+    created_at: string; // ISO 8601
+    content: string;
+    likes: number;
+    retweets: number;
+    replies: number;
+    views: number;
+    isPinned: boolean;
+}
+
+interface FeedProfile {
+    name: string;
+    handle: string;
+    description: string;
+    followers: number;
+    following: number;
+    avatar: string;
+}
+
+interface FeedPayload {
+    success: boolean;
+    source: 'x-api' | 'apify' | 'none';
+    profile: FeedProfile | null;
+    tweets: FeedTweet[];
+    timestamp: string;
+}
+
+function num(v: unknown): number {
+    const n = typeof v === 'string' ? parseInt(v.replace(/[^0-9]/g, ''), 10) : Number(v);
+    return Number.isFinite(n) ? n : 0;
+}
+
+// ── Source 1: Official X API v2 ───────────────────────────────────────
+async function fetchViaXApi(): Promise<FeedPayload | null> {
+    if (!X_BEARER) return null;
+    const headers = { Authorization: `Bearer ${X_BEARER}` };
+
+    const userRes = await fetch(
+        `https://api.twitter.com/2/users/by/username/${HANDLE}?user.fields=name,description,profile_image_url,public_metrics`,
+        { headers, signal: AbortSignal.timeout(10000) },
+    );
+    if (!userRes.ok) throw new Error(`X API user: ${userRes.status}`);
+    const userJson = await userRes.json();
+    const u = userJson.data;
+    if (!u) throw new Error('X API: no user');
+
+    const tweetsRes = await fetch(
+        `https://api.twitter.com/2/users/${u.id}/tweets?max_results=10&exclude=replies&tweet.fields=created_at,public_metrics`,
+        { headers, signal: AbortSignal.timeout(10000) },
+    );
+    if (!tweetsRes.ok) throw new Error(`X API tweets: ${tweetsRes.status}`);
+    const tweetsJson = await tweetsRes.json();
+
+    const tweets: FeedTweet[] = (tweetsJson.data || []).map((t: any) => ({
+        id: t.id,
+        created_at: t.created_at,
+        content: t.text || '',
+        likes: num(t.public_metrics?.like_count),
+        retweets: num(t.public_metrics?.retweet_count),
+        replies: num(t.public_metrics?.reply_count),
+        views: num(t.public_metrics?.impression_count),
+        isPinned: false,
+    }));
+
+    return {
+        success: true,
+        source: 'x-api',
+        profile: {
+            name: u.name || 'Aleister',
+            handle: HANDLE,
+            description: u.description || '',
+            followers: num(u.public_metrics?.followers_count),
+            following: num(u.public_metrics?.following_count),
+            // upgrade the default normal-res avatar to higher res
+            avatar: (u.profile_image_url || '').replace('_normal', '_400x400'),
+        },
+        tweets,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+// ── Source 2: Apify tweet-scraper ─────────────────────────────────────
+async function fetchViaApify(): Promise<FeedPayload | null> {
+    if (!APIFY_TOKEN) return null;
+    const url = `https://api.apify.com/v2/acts/apidojo~tweet-scraper/run-sync-get-dataset-items?token=${APIFY_TOKEN}`;
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            twitterHandles: [HANDLE],
+            maxItems: 12,
+            sort: 'Latest',
+        }),
+        signal: AbortSignal.timeout(90000),
+    });
+    if (!res.ok) throw new Error(`Apify: ${res.status}`);
+    const items: any[] = await res.json();
+    if (!Array.isArray(items) || items.length === 0) {
+        throw new Error('Apify: empty dataset');
+    }
+
+    // Defensive field extraction — Apify Twitter actor field names vary.
+    const tweets: FeedTweet[] = items
+        .filter((t) => t && (t.text || t.fullText || t.full_text))
+        .map((t) => ({
+            id: String(t.id ?? t.tweetId ?? t.id_str ?? ''),
+            created_at: t.createdAt ?? t.created_at ?? t.date ?? '',
+            content: t.text ?? t.fullText ?? t.full_text ?? '',
+            likes: num(t.likeCount ?? t.favoriteCount ?? t.favorite_count ?? t.likes),
+            retweets: num(t.retweetCount ?? t.retweet_count ?? t.retweets),
+            replies: num(t.replyCount ?? t.reply_count ?? t.replies),
+            views: num(t.viewCount ?? t.viewsCount ?? t.views ?? t.impressions),
+            isPinned: Boolean(t.isPinned ?? t.pinned ?? false),
+        }))
+        .slice(0, 10);
+
+    // Author/profile is embedded on each tweet item
+    const a =
+        items[0].author ||
+        items[0].user ||
+        items[0].authorMeta ||
+        {};
+    const profile: FeedProfile = {
+        name: a.name ?? a.displayName ?? 'Aleister',
+        handle: HANDLE,
+        description: a.description ?? a.bio ?? a.rawDescription ?? '',
+        followers: num(a.followers ?? a.followersCount ?? a.followers_count),
+        following: num(a.following ?? a.followingCount ?? a.friends_count ?? a.followingCount),
+        avatar: (a.profilePicture ?? a.profileImageUrl ?? a.avatar ?? '').replace(
+            '_normal',
+            '_400x400',
+        ),
+    };
+
+    return {
+        success: true,
+        source: 'apify',
+        profile,
+        tweets,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+export const GET: APIRoute = async () => {
+    // Serve fresh cache
+    if (cache && Date.now() - cache.timestamp < CACHE_TTL) {
+        return json(cache.data);
+    }
+
+    try {
+        // Prefer the official API, fall back to Apify
+        let payload: FeedPayload | null = null;
+        try {
+            payload = await fetchViaXApi();
+        } catch (e) {
+            console.error('x-feed: X API failed, trying Apify:', e);
+        }
+        if (!payload) {
+            payload = await fetchViaApify();
+        }
+
+        if (payload && payload.tweets.length > 0) {
+            cache = { data: payload, timestamp: Date.now() };
+            return json(payload);
+        }
+
+        // Both sources unavailable
+        return json({
+            success: false,
+            source: 'none',
+            profile: null,
+            tweets: [],
+            timestamp: new Date().toISOString(),
+        });
+    } catch (error) {
+        console.error('x-feed error:', error);
+        // Serve stale cache if we have any, else signal failure
+        if (cache) return json(cache.data);
+        return json({
+            success: false,
+            source: 'none',
+            profile: null,
+            tweets: [],
+            timestamp: new Date().toISOString(),
+        });
+    }
+};
+
+function json(data: FeedPayload): Response {
+    return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Cache-Control': 'public, max-age=300, stale-while-revalidate=86400',
+        },
+    });
+}


### PR DESCRIPTION
## Summary

The home **Feed** section claimed "Live posts from @aleisterai on X" but was 100% hardcoded at build time. It now pulls real data on every load.

### New endpoint `/api/x-feed.json`
- **Source priority:** official **X API v2** when `X_BEARER_TOKEN` is set (canonical + cheapest), otherwise the **Apify `apidojo/tweet-scraper`** using the existing `APIFY_TOKEN` — the same infra the YouTube/TikTok/Instagram stats already run on.
- Normalizes both sources to `{ profile, tweets }` with defensive field parsing (Apify Twitter field names vary across runs).
- **15-min server cache** + `stale-while-revalidate=86400`; serves stale on error so a transient source failure never blanks the feed.

### `Feed.astro`
- Keeps the existing posts as a **server-rendered fallback** (no empty state, no layout shift) and **replaces them with live data** when the fetch succeeds.
- Re-renders the profile avatar, bio, follower/following counts, and tweet cards client-side — markup matches the existing cards exactly.
- Tweet text is **HTML-escaped** before insertion (XSS-safe); counts compacted (`1.2K`), timestamps relative (`2h`) or dated; each card links to the specific tweet.

### ⚠️ Requires a live data source to actually go live
This wires up the *plumbing*. For it to return live data, **one of these must be true** in the Vercel env:
1. **`X_BEARER_TOKEN`** is set → uses the official X API v2 (recommended; you mentioned the agent already has X API v2 access — reuse that bearer token here), **or**
2. the existing **`APIFY_TOKEN`** plan includes the `apidojo/tweet-scraper` actor (it runs on-demand and bills per run).

If neither is available the section gracefully shows the fallback posts (same as today). **Tell me which one you want and I'll confirm the wiring** — if it's the X bearer token, just add `X_BEARER_TOKEN` in Vercel and it works immediately.

## Test plan
- [ ] With a token configured: load `/`, scroll to Feed — profile stats + tweets reflect the live @aleisterai account
- [ ] `curl /api/x-feed.json` returns `{ success: true, source: "x-api"|"apify", profile, tweets }`
- [ ] Kill the token → endpoint returns `success:false`, Feed shows fallback posts (no blank state)
- [ ] Tweet content with `<`, `&`, quotes renders as text (no markup injection)
- [ ] Mobile layout unchanged

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_