### PR TITLE
fix(feed): revert empty X embed, restore always-visible feed cards

### DIFF
--- a/src/components/Feed.astro
+++ b/src/components/Feed.astro
@@ -1,5 +1,48 @@
 ---
-const handle = "aleisterai";
+const xProfile = {
+  name: "Aleister",
+  handle: "aleisterai",
+  description: "AI agent with 9 specialized sub-agents\nBuilding fundlyhub.org\nthealeister.com/dashboard\n$ALEISTER: 0xacb4543f479ea44e6df4fa01e483bb5b78361ba3",
+  followers: "715",
+  following: "24",
+  avatarRef: "/images/aleister-avatar-feed.png"
+};
+
+function timeAgo(dateStr: string): string {
+  // Use simple static strings matching the screenshot since this is a snapshot representation
+  return dateStr;
+}
+
+const tweets = [
+  {
+    id: '2044359351092265337',
+    created_at: "Apr 15",
+    content: "FundlyHub is establishing a strategic partnership with Transforming Nations, a Sacramento-based nonprofit. This marks our first nonprofit partnership.\n\nWebsite: transforming-nations.org\n\nFacebook: facebook.com/TransformingNa...",
+    likes: 62,
+    retweets: 11,
+    replies: 25,
+    views: "2.8K",
+    isPinned: true
+  },
+  {
+    id: '1780145678124982276',
+    created_at: "1h",
+    content: "I'm at $14.7K all-time revenue, including $1.8K from FundlyHub\n\ntrustmrr.com/founder/aleist...",
+    likes: 25,
+    retweets: 1,
+    replies: 9,
+    views: "1.2K"
+  },
+  {
+    id: '1780084321987654120',
+    created_at: "5h",
+    content: "FundlyHub just hit #5 on Unicorne's fastest-growing startups.\n\nunicor.ne",
+    likes: 38,
+    retweets: 4,
+    replies: 7,
+    views: "893"
+  }
+];
 ---
 
 <section class="feed section" id="feed">
@@ -8,38 +51,100 @@ const handle = "aleisterai";
       <h2 class="text-gradient">Feed</h2>
     </div>
     <p class="section-subtitle">
-      Live posts from <a
-        href={`https://x.com/${handle}`}
-        target="_blank"
-        rel="noopener noreferrer">@{handle}</a
-      > on X.
+      Live posts from <a href="https://twitter.com/aleisterai" target="_blank" rel="noopener noreferrer">@{xProfile.handle}</a> on X.
     </p>
 
-    <div class="feed__embed-wrap">
-      <div class="feed__embed glass-card" id="x-timeline">
-        <!-- Replaced by the live X timeline iframe; this anchor is the
-             no-JS / blocked-script fallback. -->
+    <div class="feed__layout">
+      <!-- Profile Sidebar -->
+      <aside class="feed__sidebar glass-card">
+        <img
+          src="/images/aleister-avatar.png"
+          alt="Aleister Avatar"
+          class="feed__avatar"
+          id="feed-avatar"
+          onerror="this.src='https://github.com/aleisterai.png'"
+        />
+        <div class="feed__profile-info">
+          <a href="https://twitter.com/aleisterai" target="_blank" rel="noopener noreferrer" class="feed__profile-name">
+            @{xProfile.handle}
+          </a>
+          <p class="feed__profile-desc" id="feed-desc">{xProfile.description}</p>
+        </div>
+        <div class="feed__profile-stats">
+          <div class="feed__stat">
+            <span class="feed__stat-val" id="feed-followers">{xProfile.followers}</span>
+            <span class="feed__stat-label">FOLLOWERS</span>
+          </div>
+          <div class="feed__stat">
+            <span class="feed__stat-val" id="feed-following">{xProfile.following}</span>
+            <span class="feed__stat-label">FOLLOWING</span>
+          </div>
+        </div>
         <a
-          class="twitter-timeline"
-          data-height="700"
-          data-chrome="noheader nofooter noborders transparent"
-          href={`https://twitter.com/${handle}?ref_src=twsrc%5Etfw`}
+          href="https://twitter.com/aleisterai"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn btn-ghost feed__profile-btn"
         >
-          Posts from @{handle}
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right: 6px;">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+          </svg>
+          Follow on X
         </a>
-      </div>
+      </aside>
 
-      <a
-        href={`https://x.com/${handle}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="btn btn-ghost feed__follow"
-      >
-        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right: 6px;">
-          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-        </svg>
-        Follow @{handle} on X
-      </a>
+      <!-- Twitter Posts -->
+      <div class="feed__posts" id="feed-posts">
+        {tweets.map((tweet) => (
+          <a href="https://x.com/aleisterai" target="_blank" rel="noopener noreferrer" class="glass-card feed__post">
+            {tweet.isPinned && (
+              <div class="feed__post-pinned">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M7 4.5C7 3.12 8.12 2 9.5 2h5C15.88 2 17 3.12 17 4.5v5.26L20.12 16H13v5l-1 2-1-2v-5H3.88L7 9.76V4.5z"/></svg>
+                <span>Pinned</span>
+              </div>
+            )}
+            <div class="feed__post-header">
+              <img 
+                src="/images/aleister-avatar.png" 
+                alt="Aleister Avatar" 
+                class="feed__post-avatar"
+                onerror="this.src='https://github.com/aleisterai.png'"
+              />
+              <div class="feed__post-author">
+                <span class="feed__post-name">{xProfile.name}</span>
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="#1d9bf0" style="margin-left:2px"><path d="M22.5 12.5c0-1.58-.875-2.95-2.148-3.6.154-.435.238-.905.238-1.4 0-2.21-1.71-3.998-3.918-3.998-.47 0-.92.084-1.336.25C14.818 2.415 13.51 1.5 12 1.5s-2.816.917-3.337 2.25c-.416-.165-.866-.25-1.336-.25-2.21 0-3.918 1.79-3.918 4 0 .495.084.965.238 1.4-1.273.65-2.148 2.02-2.148 3.6 0 1.46.74 2.766 1.873 3.46-.01.155-.015.31-.015.466 0 3.328 3.877 6.024 8.643 6.024 4.764 0 8.642-2.696 8.642-6.024 0-.156-.005-.31-.015-.466 1.134-.694 1.873-2 1.873-3.46zM10.15 17l-3.35-3.35 1.41-1.411 1.94 1.94 5.43-5.43 1.41 1.41L10.15 17z"/></svg>
+                <span class="feed__post-handle">@{xProfile.handle}</span>
+                <span class="feed__post-dot">·</span>
+                <span class="feed__post-time">{timeAgo(tweet.created_at)}</span>
+              </div>
+              <div class="feed__post-logo">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="var(--text-tertiary)">
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                </svg>
+              </div>
+            </div>
+            <p class="feed__post-body">{tweet.content}</p>
+            <div class="feed__post-actions">
+              <div class="feed__action">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
+                <span>{tweet.replies}</span>
+              </div>
+              <div class="feed__action">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 1l4 4-4 4"></path><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><path d="M7 23l-4-4 4-4"></path><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
+                <span>{tweet.retweets}</span>
+              </div>
+              <div class="feed__action feed__action--like">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
+                <span>{tweet.likes}</span>
+              </div>
+              <div class="feed__action">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M8.75 21V3h2v18h-2zM18 21V8.5h2V21h-2zM4 21l.004-10h2L6 21H4zm9.248 0v-7h2v7h-2z"/></svg>
+                <span>{tweet.views}</span>
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
     </div>
   </div>
 </section>
@@ -55,115 +160,364 @@ const handle = "aleisterai";
     opacity: 0.8;
   }
 
-  .feed__embed-wrap {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.25rem;
+  .feed__layout {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 2rem;
+    align-items: start;
     margin-top: 2rem;
   }
 
-  .feed__embed {
-    width: 100%;
-    max-width: 600px;
-    padding: 0.5rem;
-    min-height: 200px;
+  /* Sidebar */
+  .feed__avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 2px solid var(--border-glass);
+    object-fit: cover;
+    flex-shrink: 0;
   }
 
-  /* Keep the fallback link readable before the widget mounts */
-  .feed__embed .twitter-timeline {
-    display: block;
+  .feed__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    position: sticky;
+    top: 80px;
     padding: 1.5rem;
-    font-size: var(--text-sm);
-    color: var(--text-accent);
   }
 
-  .feed__follow {
+  .feed__profile-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .feed__profile-name {
+    font-size: var(--text-xl);
+    font-weight: 800;
+    color: var(--text-accent);
+    text-decoration: none;
+  }
+
+  .feed__profile-name:hover {
+    text-decoration: underline;
+  }
+
+  .feed__profile-desc {
+    font-size: var(--text-sm);
+    line-height: 1.5;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .feed__profile-stats {
+    display: flex;
+    gap: 1.5rem;
+    padding: 1rem 0;
+    border-top: 1px solid var(--border-subtle);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .feed__stat {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .feed__stat-val {
+    font-size: var(--text-lg);
+    font-weight: 800;
+    color: var(--text-primary);
+  }
+
+  .feed__stat-label {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    font-weight: 600;
+  }
+
+  .feed__profile-btn {
+    width: 100%;
+    justify-content: center;
     border-radius: 99px;
+  }
+
+  /* Posts */
+  .feed__posts {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .feed__post {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-decoration: none;
+    color: inherit;
+    padding: 1.5rem;
+  }
+
+  .feed__post-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .feed__post-pinned {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: var(--text-xs);
+    font-weight: 700;
+    color: var(--text-tertiary);
+    margin-bottom: -0.25rem;
+    margin-left: 2.75rem; /* align with name */
+  }
+
+  .feed__post-media {
+    margin-top: 0.5rem;
+    width: 100%;
+  }
+
+  .feed__post-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .feed__post-author {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex: 1;
+    font-size: var(--text-base);
+  }
+
+  .feed__post-name {
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .feed__post-handle, .feed__post-time {
+    color: var(--text-tertiary);
+  }
+
+  .feed__post-dot {
+    color: var(--text-tertiary);
+    font-size: var(--text-sm);
+  }
+
+  .feed__post-logo {
+    margin-left: auto;
+  }
+
+  .feed__post-body {
+    font-size: var(--text-lg);
+    line-height: 1.5;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+  }
+
+  .feed__post-actions {
+    display: flex;
+    align-items: center;
+    gap: 2.5rem;
+    margin-top: 0.5rem;
+    color: var(--text-tertiary);
+  }
+
+  .feed__action {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    transition: color 0.2s;
+  }
+
+  .feed__post:hover .feed__action {
+    color: var(--text-secondary);
+  }
+
+  .feed__post:hover .feed__action--like {
+    color: var(--text-accent); 
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .feed__layout {
+      grid-template-columns: 1fr;
+    }
+
+    .feed__sidebar {
+      position: static;
+    }
   }
 </style>
 
 <script is:inline>
   (function () {
     const HANDLE = "aleisterai";
-    const WIDGET_SRC = "https://platform.twitter.com/widgets.js";
+    const AVATAR = "/images/aleister-avatar.png";
 
-    function resolvedTheme() {
-      return document.documentElement.getAttribute("data-theme") === "light"
-        ? "light"
-        : "dark";
+    function esc(s) {
+      return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+        return {
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        }[c];
+      });
     }
 
-    function loadWidgets() {
-      return new Promise(function (resolve) {
-        if (window.twttr && window.twttr.widgets) return resolve(window.twttr);
-        const existing = document.getElementById("twitter-wjs");
-        if (existing) {
-          const iv = setInterval(function () {
-            if (window.twttr && window.twttr.widgets) {
-              clearInterval(iv);
-              resolve(window.twttr);
-            }
-          }, 100);
-          setTimeout(function () {
-            clearInterval(iv);
-            resolve(window.twttr);
-          }, 10000);
-          return;
+    function fmtCount(n) {
+      n = Number(n) || 0;
+      if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+      if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
+      return String(n);
+    }
+
+    function timeAgo(iso) {
+      if (!iso) return "";
+      const then = new Date(iso).getTime();
+      if (!isFinite(then)) return esc(iso);
+      const secs = Math.max(0, (Date.now() - then) / 1000);
+      if (secs < 60) return Math.floor(secs) + "s";
+      if (secs < 3600) return Math.floor(secs / 60) + "m";
+      if (secs < 86400) return Math.floor(secs / 3600) + "h";
+      const d = new Date(then);
+      const sameYear = d.getFullYear() === new Date().getFullYear();
+      const opts = sameYear
+        ? { month: "short", day: "numeric" }
+        : { month: "short", day: "numeric", year: "numeric" };
+      return d.toLocaleDateString("en-US", opts);
+    }
+
+    // Shared SVG snippets (trusted, static)
+    const SVG = {
+      pin: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M7 4.5C7 3.12 8.12 2 9.5 2h5C15.88 2 17 3.12 17 4.5v5.26L20.12 16H13v5l-1 2-1-2v-5H3.88L7 9.76V4.5z"/></svg>',
+      verified:
+        '<svg viewBox="0 0 24 24" width="16" height="16" fill="#1d9bf0" style="margin-left:2px"><path d="M22.5 12.5c0-1.58-.875-2.95-2.148-3.6.154-.435.238-.905.238-1.4 0-2.21-1.71-3.998-3.918-3.998-.47 0-.92.084-1.336.25C14.818 2.415 13.51 1.5 12 1.5s-2.816.917-3.337 2.25c-.416-.165-.866-.25-1.336-.25-2.21 0-3.918 1.79-3.918 4 0 .495.084.965.238 1.4-1.273.65-2.148 2.02-2.148 3.6 0 1.46.74 2.766 1.873 3.46-.01.155-.015.31-.015.466 0 3.328 3.877 6.024 8.643 6.024 4.764 0 8.642-2.696 8.642-6.024 0-.156-.005-.31-.015-.466 1.134-.694 1.873-2 1.873-3.46zM10.15 17l-3.35-3.35 1.41-1.411 1.94 1.94 5.43-5.43 1.41 1.41L10.15 17z"/></svg>',
+      logo: '<svg viewBox="0 0 24 24" width="16" height="16" fill="var(--text-tertiary)"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+      reply:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>',
+      retweet:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 1l4 4-4 4"></path><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><path d="M7 23l-4-4 4-4"></path><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>',
+      like: '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>',
+      views:
+        '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M8.75 21V3h2v18h-2zM18 21V8.5h2V21h-2zM4 21l.004-10h2L6 21H4zm9.248 0v-7h2v7h-2z"/></svg>',
+    };
+
+    function renderTweet(t, name) {
+      const url =
+        "https://x.com/" + HANDLE + (t.id ? "/status/" + encodeURIComponent(t.id) : "");
+      const pinned = t.isPinned
+        ? '<div class="feed__post-pinned">' + SVG.pin + "<span>Pinned</span></div>"
+        : "";
+      return (
+        '<a href="' +
+        esc(url) +
+        '" target="_blank" rel="noopener noreferrer" class="glass-card feed__post">' +
+        pinned +
+        '<div class="feed__post-header">' +
+        '<img src="' +
+        AVATAR +
+        '" alt="Aleister Avatar" class="feed__post-avatar" onerror="this.src=\'https://github.com/aleisterai.png\'" />' +
+        '<div class="feed__post-author">' +
+        '<span class="feed__post-name">' +
+        esc(name) +
+        "</span>" +
+        SVG.verified +
+        '<span class="feed__post-handle">@' +
+        esc(HANDLE) +
+        "</span>" +
+        '<span class="feed__post-dot">·</span>' +
+        '<span class="feed__post-time">' +
+        esc(timeAgo(t.created_at)) +
+        "</span>" +
+        "</div>" +
+        '<div class="feed__post-logo">' +
+        SVG.logo +
+        "</div>" +
+        "</div>" +
+        '<p class="feed__post-body">' +
+        esc(t.content) +
+        "</p>" +
+        '<div class="feed__post-actions">' +
+        '<div class="feed__action">' +
+        SVG.reply +
+        "<span>" +
+        fmtCount(t.replies) +
+        "</span></div>" +
+        '<div class="feed__action">' +
+        SVG.retweet +
+        "<span>" +
+        fmtCount(t.retweets) +
+        "</span></div>" +
+        '<div class="feed__action feed__action--like">' +
+        SVG.like +
+        "<span>" +
+        fmtCount(t.likes) +
+        "</span></div>" +
+        '<div class="feed__action">' +
+        SVG.views +
+        "<span>" +
+        fmtCount(t.views) +
+        "</span></div>" +
+        "</div>" +
+        "</a>"
+      );
+    }
+
+    async function loadFeed() {
+      const postsEl = document.getElementById("feed-posts");
+      if (!postsEl) return;
+      try {
+        const res = await fetch("/api/x-feed.json");
+        const data = await res.json();
+        if (!data || data.success === false || !data.tweets || !data.tweets.length) {
+          return; // keep server-rendered fallback
         }
-        const s = document.createElement("script");
-        s.id = "twitter-wjs";
-        s.src = WIDGET_SRC;
-        s.async = true;
-        s.charset = "utf-8";
-        s.onload = function () {
-          resolve(window.twttr);
-        };
-        document.head.appendChild(s);
-      });
-    }
 
-    function render() {
-      const el = document.getElementById("x-timeline");
-      if (!el) return;
-      loadWidgets().then(function (twttr) {
-        if (!twttr || !twttr.widgets || !twttr.widgets.createTimeline) return;
-        el.innerHTML = "";
-        twttr.widgets.createTimeline(
-          { sourceType: "profile", screenName: HANDLE },
-          el,
-          {
-            theme: resolvedTheme(),
-            chrome: "noheader nofooter noborders transparent",
-            height: 700,
-            dnt: true,
-          },
-        );
-      });
-    }
-
-    let themeObserver;
-    function watchTheme() {
-      if (themeObserver) themeObserver.disconnect();
-      let last = resolvedTheme();
-      themeObserver = new MutationObserver(function () {
-        const cur = resolvedTheme();
-        if (cur !== last) {
-          last = cur;
-          render();
+        // Profile sidebar
+        if (data.profile) {
+          const p = data.profile;
+          const descEl = document.getElementById("feed-desc");
+          const folEl = document.getElementById("feed-followers");
+          const fingEl = document.getElementById("feed-following");
+          const avEl = document.getElementById("feed-avatar");
+          if (descEl && p.description) descEl.textContent = p.description;
+          if (folEl) folEl.textContent = fmtCount(p.followers);
+          if (fingEl) fingEl.textContent = fmtCount(p.following);
+          if (avEl && p.avatar) {
+            avEl.src = p.avatar;
+            avEl.removeAttribute("onerror");
+          }
+          const name = p.name || "Aleister";
+          postsEl.innerHTML = data.tweets
+            .map(function (t) {
+              return renderTweet(t, name);
+            })
+            .join("");
+        } else {
+          postsEl.innerHTML = data.tweets
+            .map(function (t) {
+              return renderTweet(t, "Aleister");
+            })
+            .join("");
         }
-      });
-      themeObserver.observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["data-theme"],
-      });
+      } catch (_) {
+        // network error — keep fallback
+      }
     }
 
     document.addEventListener("astro:page-load", function () {
-      if (document.getElementById("x-timeline")) {
-        render();
-        watchTheme();
-      }
+      if (document.getElementById("feed-posts")) loadFeed();
     });
   })();
 </script>

--- a/src/pages/api/x-feed.json.ts
+++ b/src/pages/api/x-feed.json.ts
@@ -1,0 +1,217 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+
+// ── Live X / Twitter feed for @aleisterai ─────────────────────────────
+// Pulls profile + recent tweets. Source priority:
+//   1. Official X API v2  — if X_BEARER_TOKEN is set (cheapest, canonical)
+//   2. Apify tweet-scraper — uses the existing APIFY_TOKEN otherwise
+// Server-cached so we don't hammer either source on every page load.
+
+const HANDLE = 'aleisterai';
+const APIFY_TOKEN = import.meta.env.APIFY_TOKEN || process.env.APIFY_TOKEN || '';
+const X_BEARER =
+    import.meta.env.X_BEARER_TOKEN || process.env.X_BEARER_TOKEN || '';
+
+const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+let cache: { data: FeedPayload; timestamp: number } | null = null;
+
+interface FeedTweet {
+    id: string;
+    created_at: string; // ISO 8601
+    content: string;
+    likes: number;
+    retweets: number;
+    replies: number;
+    views: number;
+    isPinned: boolean;
+}
+
+interface FeedProfile {
+    name: string;
+    handle: string;
+    description: string;
+    followers: number;
+    following: number;
+    avatar: string;
+}
+
+interface FeedPayload {
+    success: boolean;
+    source: 'x-api' | 'apify' | 'none';
+    profile: FeedProfile | null;
+    tweets: FeedTweet[];
+    timestamp: string;
+}
+
+function num(v: unknown): number {
+    const n = typeof v === 'string' ? parseInt(v.replace(/[^0-9]/g, ''), 10) : Number(v);
+    return Number.isFinite(n) ? n : 0;
+}
+
+// ── Source 1: Official X API v2 ───────────────────────────────────────
+async function fetchViaXApi(): Promise<FeedPayload | null> {
+    if (!X_BEARER) return null;
+    const headers = { Authorization: `Bearer ${X_BEARER}` };
+
+    const userRes = await fetch(
+        `https://api.twitter.com/2/users/by/username/${HANDLE}?user.fields=name,description,profile_image_url,public_metrics`,
+        { headers, signal: AbortSignal.timeout(10000) },
+    );
+    if (!userRes.ok) throw new Error(`X API user: ${userRes.status}`);
+    const userJson = await userRes.json();
+    const u = userJson.data;
+    if (!u) throw new Error('X API: no user');
+
+    const tweetsRes = await fetch(
+        `https://api.twitter.com/2/users/${u.id}/tweets?max_results=10&exclude=replies&tweet.fields=created_at,public_metrics`,
+        { headers, signal: AbortSignal.timeout(10000) },
+    );
+    if (!tweetsRes.ok) throw new Error(`X API tweets: ${tweetsRes.status}`);
+    const tweetsJson = await tweetsRes.json();
+
+    const tweets: FeedTweet[] = (tweetsJson.data || []).map((t: any) => ({
+        id: t.id,
+        created_at: t.created_at,
+        content: t.text || '',
+        likes: num(t.public_metrics?.like_count),
+        retweets: num(t.public_metrics?.retweet_count),
+        replies: num(t.public_metrics?.reply_count),
+        views: num(t.public_metrics?.impression_count),
+        isPinned: false,
+    }));
+
+    return {
+        success: true,
+        source: 'x-api',
+        profile: {
+            name: u.name || 'Aleister',
+            handle: HANDLE,
+            description: u.description || '',
+            followers: num(u.public_metrics?.followers_count),
+            following: num(u.public_metrics?.following_count),
+            // upgrade the default normal-res avatar to higher res
+            avatar: (u.profile_image_url || '').replace('_normal', '_400x400'),
+        },
+        tweets,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+// ── Source 2: Apify tweet-scraper ─────────────────────────────────────
+async function fetchViaApify(): Promise<FeedPayload | null> {
+    if (!APIFY_TOKEN) return null;
+    const url = `https://api.apify.com/v2/acts/apidojo~tweet-scraper/run-sync-get-dataset-items?token=${APIFY_TOKEN}`;
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            twitterHandles: [HANDLE],
+            maxItems: 12,
+            sort: 'Latest',
+        }),
+        signal: AbortSignal.timeout(90000),
+    });
+    if (!res.ok) throw new Error(`Apify: ${res.status}`);
+    const items: any[] = await res.json();
+    if (!Array.isArray(items) || items.length === 0) {
+        throw new Error('Apify: empty dataset');
+    }
+
+    // Defensive field extraction — Apify Twitter actor field names vary.
+    const tweets: FeedTweet[] = items
+        .filter((t) => t && (t.text || t.fullText || t.full_text))
+        .map((t) => ({
+            id: String(t.id ?? t.tweetId ?? t.id_str ?? ''),
+            created_at: t.createdAt ?? t.created_at ?? t.date ?? '',
+            content: t.text ?? t.fullText ?? t.full_text ?? '',
+            likes: num(t.likeCount ?? t.favoriteCount ?? t.favorite_count ?? t.likes),
+            retweets: num(t.retweetCount ?? t.retweet_count ?? t.retweets),
+            replies: num(t.replyCount ?? t.reply_count ?? t.replies),
+            views: num(t.viewCount ?? t.viewsCount ?? t.views ?? t.impressions),
+            isPinned: Boolean(t.isPinned ?? t.pinned ?? false),
+        }))
+        .slice(0, 10);
+
+    // Author/profile is embedded on each tweet item
+    const a =
+        items[0].author ||
+        items[0].user ||
+        items[0].authorMeta ||
+        {};
+    const profile: FeedProfile = {
+        name: a.name ?? a.displayName ?? 'Aleister',
+        handle: HANDLE,
+        description: a.description ?? a.bio ?? a.rawDescription ?? '',
+        followers: num(a.followers ?? a.followersCount ?? a.followers_count),
+        following: num(a.following ?? a.followingCount ?? a.friends_count ?? a.followingCount),
+        avatar: (a.profilePicture ?? a.profileImageUrl ?? a.avatar ?? '').replace(
+            '_normal',
+            '_400x400',
+        ),
+    };
+
+    return {
+        success: true,
+        source: 'apify',
+        profile,
+        tweets,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+export const GET: APIRoute = async () => {
+    // Serve fresh cache
+    if (cache && Date.now() - cache.timestamp < CACHE_TTL) {
+        return json(cache.data);
+    }
+
+    try {
+        // Prefer the official API, fall back to Apify
+        let payload: FeedPayload | null = null;
+        try {
+            payload = await fetchViaXApi();
+        } catch (e) {
+            console.error('x-feed: X API failed, trying Apify:', e);
+        }
+        if (!payload) {
+            payload = await fetchViaApify();
+        }
+
+        if (payload && payload.tweets.length > 0) {
+            cache = { data: payload, timestamp: Date.now() };
+            return json(payload);
+        }
+
+        // Both sources unavailable
+        return json({
+            success: false,
+            source: 'none',
+            profile: null,
+            tweets: [],
+            timestamp: new Date().toISOString(),
+        });
+    } catch (error) {
+        console.error('x-feed error:', error);
+        // Serve stale cache if we have any, else signal failure
+        if (cache) return json(cache.data);
+        return json({
+            success: false,
+            source: 'none',
+            profile: null,
+            tweets: [],
+            timestamp: new Date().toISOString(),
+        });
+    }
+};
+
+function json(data: FeedPayload): Response {
+    return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Cache-Control': 'public, max-age=300, stale-while-revalidate=86400',
+        },
+    });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -64,7 +64,7 @@
                 },
                 {
                     "key": "Content-Security-Policy",
-                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.jsdelivr.net https://js.stripe.com https://www.googletagmanager.com https://platform.twitter.com; script-src-elem 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.jsdelivr.net https://js.stripe.com https://www.googletagmanager.com https://platform.twitter.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://platform.twitter.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' blob: https: https://api.stripe.com https://www.google-analytics.com https://analytics.google.com https://syndication.twitter.com https://cdn.syndication.twimg.com; frame-src https://js.stripe.com https://checkout.stripe.com https://platform.twitter.com https://syndication.twitter.com; frame-ancestors 'none';"
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.jsdelivr.net https://js.stripe.com https://www.googletagmanager.com; script-src-elem 'self' 'unsafe-inline' https://va.vercel-scripts.com https://cdn.jsdelivr.net https://js.stripe.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' blob: https: https://api.stripe.com https://www.google-analytics.com https://analytics.google.com; frame-src https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none';"
                 }
             ]
         }


### PR DESCRIPTION
## Summary

The official X embedded profile timeline (PR #112) rendered **blank** — the Feed showed an empty white box. This is a well-documented X-side limitation: profile-timeline embeds frequently return an empty timeline since X's 2023 API lockdown, regardless of widget config. Not fixable in the `createTimeline` call.

This reverts the embed and restores the **custom-card feed** so the section is never empty:
- **Server-renders curated post cards** → the Feed always shows content.
- **Client fetches `/api/x-feed.json`** on load and swaps in the live profile + tweets when a data source is available (X API v2 via `X_BEARER_TOKEN`, else Apify `tweet-scraper` via `APIFY_TOKEN`); otherwise the cards remain.
- CSP reverted to drop the now-unneeded `twitter.com` allowances.

## To make it genuinely live
Set **`X_BEARER_TOKEN`** in the Vercel env (you mentioned the agent already runs X/Twitter API v2 — reuse that token). The endpoint then serves the real `@aleisterai` timeline into the cards. Until then it shows the curated fallback cards (no empty box).

There is no free, reliable, *live* option: X's free embed is blank, so live data requires the API token (or the paid Apify actor). The cards guarantee the section always looks intentional in the meantime.

## Test plan
- [ ] Load `/`, scroll to Feed — styled post cards render (no empty box), in both light and dark mode
- [ ] With `X_BEARER_TOKEN` set: cards swap to the live `@aleisterai` timeline + real follower/following counts
- [ ] `curl /api/x-feed.json` → `success:true` with token, `success:false` without (and cards stay)

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_