### PR TITLE
feat(projects): theme-aware logo support for Agent Coliseum

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -12,7 +12,38 @@ import { projects } from '../data/projects';
       {projects.map((project) => (
         <a href={`/projects/${project.slug}`} class="glass-card project-card">
           <div class="project-card__header">
-            {project.logo ? (
+            {project.logoForLight || project.logoForDark ? (
+              <span
+                class="project-card__mark"
+                style={`--monogram-color: ${project.color}`}
+              >
+                {project.logoForLight && (
+                  <img
+                    src={project.logoForLight}
+                    alt={`${project.name} logo`}
+                    class="project-card__logo project-card__logo--light"
+                    width="40"
+                    height="40"
+                    loading="lazy"
+                    onerror="this.remove()"
+                  />
+                )}
+                {project.logoForDark && (
+                  <img
+                    src={project.logoForDark}
+                    alt={`${project.name} logo`}
+                    class="project-card__logo project-card__logo--dark"
+                    width="40"
+                    height="40"
+                    loading="lazy"
+                    onerror="this.remove()"
+                  />
+                )}
+                <span class="project-card__monogram-fallback" aria-hidden="true">
+                  {project.name.charAt(0)}
+                </span>
+              </span>
+            ) : project.logo ? (
               <img
                 src={project.logo}
                 alt={`${project.name} logo`}
@@ -82,6 +113,50 @@ import { projects } from '../data/projects';
     height: 40px;
     border-radius: 8px;
     flex-shrink: 0;
+    font-size: var(--text-xl);
+    font-weight: 800;
+    color: var(--monogram-color, var(--text-accent));
+    background: color-mix(in srgb, var(--monogram-color, var(--text-accent)) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--monogram-color, var(--text-accent)) 35%, transparent);
+  }
+
+  /* Theme-aware mark: light/dark logos layered over a monogram fallback.
+     The monogram sits underneath; a loaded logo (opaque, own background)
+     covers it. If a logo file 404s its <img> is removed (onerror) and the
+     monogram shows through. */
+  .project-card__mark {
+    position: relative;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+  }
+
+  .project-card__mark .project-card__logo {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+
+  .project-card__logo--dark {
+    display: none;
+  }
+
+  :global([data-theme="dark"]) .project-card__logo--light {
+    display: none;
+  }
+
+  :global([data-theme="dark"]) .project-card__logo--dark {
+    display: block;
+  }
+
+  .project-card__monogram-fallback {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
     font-size: var(--text-xl);
     font-weight: 800;
     color: var(--monogram-color, var(--text-accent));

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -9,6 +9,11 @@ export interface Project {
     tags: string[];
     color: string;
     logo?: string;
+    /** Theme-specific marks. Shown on light vs. dark pages respectively.
+     *  logoForLight = the dark-background mark (pops on a light page);
+     *  logoForDark  = the light-background mark (pops on a dark page). */
+    logoForLight?: string;
+    logoForDark?: string;
 }
 
 export const projects: Project[] = [
@@ -24,6 +29,11 @@ export const projects: Project[] = [
         role: 'CEO',
         tags: ['AI Agents', 'Competition', 'Autonomy', 'Arena'],
         color: '#f59e0b',
+        // Light mode shows the dark-background mark; dark mode shows the
+        // light-background mark. Falls back to the color monogram until
+        // these files are added to /public/logos/.
+        logoForLight: '/logos/agent-coliseum-logomark-dark.png',
+        logoForDark: '/logos/agent-coliseum-logomark-light.png',
     },
     {
         slug: 'fundlyhub',

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -33,7 +33,36 @@ try {
 
             <header class="project__header">
                 {
-                    project.logo ? (
+                    project.logoForLight || project.logoForDark ? (
+                        <span
+                            class="project__mark"
+                            style={`--monogram-color: ${project.color}`}
+                        >
+                            {project.logoForLight && (
+                                <img
+                                    src={project.logoForLight}
+                                    alt={`${project.name} logo`}
+                                    class="project__logo project__logo--light"
+                                    width="64"
+                                    height="64"
+                                    onerror="this.remove()"
+                                />
+                            )}
+                            {project.logoForDark && (
+                                <img
+                                    src={project.logoForDark}
+                                    alt={`${project.name} logo`}
+                                    class="project__logo project__logo--dark"
+                                    width="64"
+                                    height="64"
+                                    onerror="this.remove()"
+                                />
+                            )}
+                            <span class="project__monogram-fallback" aria-hidden="true">
+                                {project.name.charAt(0)}
+                            </span>
+                        </span>
+                    ) : project.logo ? (
                         <img
                             src={project.logo}
                             alt={`${project.name} logo`}
@@ -122,6 +151,47 @@ try {
         height: 64px;
         border-radius: 14px;
         flex-shrink: 0;
+        font-size: var(--text-2xl);
+        font-weight: 800;
+        color: var(--monogram-color, var(--text-accent));
+        background: color-mix(in srgb, var(--monogram-color, var(--text-accent)) 14%, transparent);
+        border: 1px solid color-mix(in srgb, var(--monogram-color, var(--text-accent)) 35%, transparent);
+    }
+
+    /* Theme-aware mark with monogram fallback (see Projects.astro) */
+    .project__mark {
+        position: relative;
+        width: 64px;
+        height: 64px;
+        flex-shrink: 0;
+    }
+
+    .project__mark .project__logo {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+    }
+
+    .project__logo--dark {
+        display: none;
+    }
+
+    :global([data-theme="dark"]) .project__logo--light {
+        display: none;
+    }
+
+    :global([data-theme="dark"]) .project__logo--dark {
+        display: block;
+    }
+
+    .project__monogram-fallback {
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 14px;
         font-size: var(--text-2xl);
         font-weight: 800;
         color: var(--monogram-color, var(--text-accent));


### PR DESCRIPTION
## Summary

Adds theme-aware logo support so Agent Coliseum can show your supplied logomark pair — the dark-background mark in light mode, the light-background mark in dark mode.

- New optional `logoForLight` / `logoForDark` on the `Project` model.
- Rendered on **both** the home card and the `/projects/<slug>` page.
- Both `<img>`s are layered over the existing color **monogram fallback**: a loaded logo (opaque, own background) covers it; if a file is missing, the `<img>` removes itself via `onerror` and the monogram shows through — **no broken-image icon**.
- FundlyHub / CYTY Events single-logo rendering unchanged.

Agent Coliseum references:
- `/logos/agent-coliseum-logomark-dark.png` → **light mode** (the black-background mark)
- `/logos/agent-coliseum-logomark-light.png` → **dark mode** (the cream-background mark)

## ⚠️ Action needed — add the two image files
I can't import chat-uploaded images into the repo (no tool to write the binary files). Until these two PNGs exist in `public/logos/`, the card/page show the amber **"A" monogram**; they switch to the logos **automatically** once the files are committed. Add:

| File path | Which image |
|---|---|
| `public/logos/agent-coliseum-logomark-dark.png` | the **black-background** mark (your "logomark-dark") |
| `public/logos/agent-coliseum-logomark-light.png` | the **cream-background** mark |

(Or tell me and I'll recreate them as SVG instead.)

## Test plan
- [ ] Before files exist: card + detail page show the amber "A" monogram (no broken image)
- [ ] After files added: light mode shows the black-bg mark, dark mode shows the cream-bg mark; flip the theme toggle to confirm the swap
- [ ] FundlyHub / CYTY Events logos unchanged

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_