### PR TITLE
perf(feed): refresh the live X feed every 6 hours

### DIFF
--- a/src/pages/api/x-feed.json.ts
+++ b/src/pages/api/x-feed.json.ts
@@ -13,7 +13,7 @@ const APIFY_TOKEN = import.meta.env.APIFY_TOKEN || process.env.APIFY_TOKEN || ''
 const X_BEARER =
     import.meta.env.X_BEARER_TOKEN || process.env.X_BEARER_TOKEN || '';
 
-const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+const CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours
 let cache: { data: FeedPayload; timestamp: number } | null = null;
 
 interface FeedTweet {
@@ -211,7 +211,10 @@ function json(data: FeedPayload): Response {
         headers: {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Origin': '*',
-            'Cache-Control': 'public, max-age=300, stale-while-revalidate=86400',
+            // s-maxage gates how often the X API is actually hit: the
+            // Vercel CDN serves this cached for 6h, so X is called ~once
+            // per 6h per region (keeps pay-per-use cost to ~$1-2/mo).
+            'Cache-Control': 'public, max-age=600, s-maxage=21600, stale-while-revalidate=86400',
         },
     });
 }


### PR DESCRIPTION
## Summary

Sets the live X feed to refresh **every 6 hours** (~$1–2/month on X API v2 pay-per-use), now that `X_BEARER_TOKEN` is in the Vercel env.

- In-memory `CACHE_TTL`: 15 min → **6h**
- CDN `Cache-Control`: `max-age=600, s-maxage=21600, stale-while-revalidate=86400` — the `s-maxage=21600` is the real cost gate: Vercel serves the cached JSON to all visitors for 6h, so the X API is hit ~once per 6h per region.

The endpoint already reads `X_BEARER_TOKEN`, so once this deploys the cards fill with the live `@aleisterai` timeline + real follower/following counts.

## Verify after deploy
- Visit `https://<site>/api/x-feed.json` → should return `success: true, source: "x-api"` with real tweets
- Feed section shows live posts (replacing the curated fallback cards)
- If it shows `success: false`, the env var name likely isn't exactly `X_BEARER_TOKEN` — check the Vercel variable name

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_