### PR TITLE
fix(feed): failure diagnostics + stop caching failures for 6h

### DIFF
--- a/src/pages/api/x-feed.json.ts
+++ b/src/pages/api/x-feed.json.ts
@@ -166,12 +166,14 @@ export const GET: APIRoute = async () => {
         return json(cache.data);
     }
 
+    let xError: string | null = null;
     try {
         // Prefer the official API, fall back to Apify
         let payload: FeedPayload | null = null;
         try {
             payload = await fetchViaXApi();
         } catch (e) {
+            xError = e instanceof Error ? e.message : String(e);
             console.error('x-feed: X API failed, trying Apify:', e);
         }
         if (!payload) {
@@ -184,24 +186,12 @@ export const GET: APIRoute = async () => {
         }
 
         // Both sources unavailable
-        return json({
-            success: false,
-            source: 'none',
-            profile: null,
-            tweets: [],
-            timestamp: new Date().toISOString(),
-        });
+        return fail(xError);
     } catch (error) {
         console.error('x-feed error:', error);
         // Serve stale cache if we have any, else signal failure
         if (cache) return json(cache.data);
-        return json({
-            success: false,
-            source: 'none',
-            profile: null,
-            tweets: [],
-            timestamp: new Date().toISOString(),
-        });
+        return fail(xError ?? (error instanceof Error ? error.message : String(error)));
     }
 };
 
@@ -217,4 +207,29 @@ function json(data: FeedPayload): Response {
             'Cache-Control': 'public, max-age=600, s-maxage=21600, stale-while-revalidate=86400',
         },
     });
+}
+
+// Failure response with safe diagnostics (no secret leaked — just whether
+// a token was seen and the upstream HTTP status). Short cache so the feed
+// recovers quickly once the token/config is fixed.
+function fail(detail: string | null): Response {
+    return new Response(
+        JSON.stringify({
+            success: false,
+            source: 'none',
+            profile: null,
+            tweets: [],
+            tokenPresent: Boolean(X_BEARER),
+            detail,
+            timestamp: new Date().toISOString(),
+        }),
+        {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'public, max-age=60',
+            },
+        },
+    );
 }


### PR DESCRIPTION
## Summary

The live `/api/x-feed.json` returns `success:false, source:"none"` even though the token is in Vercel. This adds **safe diagnostics** to pinpoint why (no secret leaked):

- `tokenPresent` — whether `X_BEARER_TOKEN` was seen at runtime
- `detail` — the upstream X API error (e.g. `"X API user: 401"`)

Also fixes a real bug: failures were returned through the 6h-cache helper, so a transient failure (or a pre-token deploy) would be **cached for 6 hours**. Failures now use `max-age=60`, so the feed recovers within a minute once the config is right.

## How we'll read the result after deploy
`curl https://thealeister.com/api/x-feed.json`:
- `tokenPresent: false` → the env var isn't named exactly `X_BEARER_TOKEN` (or isn't set for Production / needs redeploy)
- `tokenPresent: true, detail: "...401"` → token invalid/expired
- `tokenPresent: true, detail: "...403"` → that token's access tier can't read this endpoint
- `tokenPresent: true, detail: "...429"` → rate-limited
- `success: true` → live feed working

https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdWGxHdwLhC93dpiKB5E7)_